### PR TITLE
Add BeamInstances Interface

### DIFF
--- a/core/src/main/java/gyro/core/BeamInstances.java
+++ b/core/src/main/java/gyro/core/BeamInstances.java
@@ -1,0 +1,9 @@
+package gyro.core;
+
+import java.util.List;
+
+public interface BeamInstances {
+
+    public List<BeamInstance> getInstances();
+
+}


### PR DESCRIPTION
This annotation is used by resources that generate multiple instances such as autoscaling groups.