### PR TITLE
Output strings using double quotes

### DIFF
--- a/core/src/main/java/gyro/lang/ast/value/StringNode.java
+++ b/core/src/main/java/gyro/lang/ast/value/StringNode.java
@@ -18,8 +18,8 @@ public class StringNode extends Node {
 
     @Override
     public void buildString(StringBuilder builder, int indentDepth) {
-        builder.append('\'');
+        builder.append('\"');
         builder.append(value);
-        builder.append('\'');
+        builder.append('\"');
     }
 }


### PR DESCRIPTION
Quick workaround to escaping issue when string has single qoutes in it. We should support escaping in strings and ensure that strings are escaped properly when written to state.