### PR TITLE
GYRO-144: Add jdk.crypto.ec module

### DIFF
--- a/cli/scripts/build-gyro-dist.sh
+++ b/cli/scripts/build-gyro-dist.sh
@@ -7,7 +7,7 @@ cd dist
 
 jlink --no-header-files \
     --no-man-pages \
-    --add-modules java.logging,java.management,java.naming,java.scripting,java.xml,jdk.unsupported,jdk.xml.dom,java.desktop,java.instrument,java.compiler,java.sql \
+    --add-modules java.logging,java.management,java.naming,java.scripting,java.xml,jdk.unsupported,jdk.xml.dom,java.desktop,java.instrument,java.compiler,java.sql,jdk.crypto.ec \
     --output gyro-rt
 
 zip -r gyro-cli-${OS_NAME}-${VERSION}.zip gyro-rt gyro


### PR DESCRIPTION
This fixes an issue with connecting to services that use Eliptical Curve SSL certificates such as Pingdom.