### PR TITLE
GYRO-157: Use generics in Credentials class

### DIFF
--- a/core/src/main/java/gyro/core/Credentials.java
+++ b/core/src/main/java/gyro/core/Credentials.java
@@ -1,6 +1,5 @@
 package gyro.core;
 
-import java.util.Map;
 import java.util.Set;
 
 import gyro.core.resource.Resource;


### PR DESCRIPTION
Each provider has their own credentials class that is more appropriate to return from this class.