### PR TITLE
GYRO-195: Fixes configured fields to be set correctly.

### DIFF
--- a/core/src/main/java/gyro/core/resource/DiffableScope.java
+++ b/core/src/main/java/gyro/core/resource/DiffableScope.java
@@ -8,8 +8,18 @@ import gyro.lang.ast.Node;
 
 public class DiffableScope extends Scope {
 
+    private boolean extended;
+
     public DiffableScope(Scope parent) {
         super(parent);
+    }
+
+    public boolean isExtended() {
+        return extended;
+    }
+
+    public void setExtended(boolean extended) {
+        this.extended = extended;
     }
 
     public Set<String> getAddedKeys() {

--- a/core/src/main/java/gyro/core/resource/ExtendsDirectiveProcessor.java
+++ b/core/src/main/java/gyro/core/resource/ExtendsDirectiveProcessor.java
@@ -26,6 +26,7 @@ public class ExtendsDirectiveProcessor extends DirectiveProcessor {
         }
 
         processSource(diffableScope, arguments.get(0));
+        diffableScope.setExtended(true);
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/gyro/core/resource/NodeEvaluator.java
+++ b/core/src/main/java/gyro/core/resource/NodeEvaluator.java
@@ -262,7 +262,7 @@ public class NodeEvaluator implements NodeVisitor<Scope, Object> {
 
         Resource resource = DiffableType.getInstance(resourceClass).newDiffable(null, name, bodyScope);
 
-        resource.initialize(new LinkedHashMap<>(bodyScope));
+        resource.initialize(bodyScope.isExtended() ? new LinkedHashMap<>(bodyScope) : bodyScope);
         scope.getFileScope().put(fullName, resource);
 
         return null;


### PR DESCRIPTION
This was caused by bodyScope to map conversion in NodeEvaluator.visitResource method that was necessary for extends directive to work during a workflow. Since a scope instance is necessary during Diffable.initialize for configured fields to be detected correctly, the fix was to detect this and handle it specially.

Eventually, we should refactor Scope.keyNodes and valueNodes so that this isn't necessary.