### PR TITLE
GYRO-270: Fix loading of plugins commands

### DIFF
--- a/cli/src/main/java/gyro/cli/Gyro.java
+++ b/cli/src/main/java/gyro/cli/Gyro.java
@@ -44,8 +44,6 @@ public class Gyro {
 
     static {
         Reflections.log = null;
-        reflections = new Reflections(new org.reflections.util.ConfigurationBuilder()
-            .setUrls(ClasspathHelper.forPackage("gyro")));
     }
 
     public static void main(String[] arguments) {
@@ -186,6 +184,11 @@ public class Gyro {
     }
 
     public static Reflections getReflections() {
+        if (reflections == null) {
+            reflections = new Reflections(new org.reflections.util.ConfigurationBuilder()
+                .setUrls(ClasspathHelper.forPackage("gyro")));
+        }
+
         return reflections;
     }
 


### PR DESCRIPTION
Reflection information is loaded too soon. This changes it to load the first time it's needed which is when commands are searched for.