### PR TITLE
GYRO-268 - Add location API for Gyro Instance

### DIFF
--- a/core/src/main/java/gyro/core/GyroInstance.java
+++ b/core/src/main/java/gyro/core/GyroInstance.java
@@ -16,4 +16,6 @@ public interface GyroInstance {
 
     public String getLaunchDate();
 
+    public String getLocation();
+
 }


### PR DESCRIPTION
In order to support automatically choosing the correct jump host, Gyro Instances need a Location concept to compare the jump host with the target host.

This PR adds the getLocation() API to GyroInstance for comparison.