### PR TITLE
Delays directive processing to be after after node evaluation.

### DIFF
--- a/core/src/main/java/gyro/core/scope/NodeEvaluator.java
+++ b/core/src/main/java/gyro/core/scope/NodeEvaluator.java
@@ -330,7 +330,9 @@ public class NodeEvaluator implements NodeVisitor<Scope, Object, RuntimeExceptio
         DiffableScope bodyScope = new DiffableScope(scope, node);
 
         for (Node item : node.getBody()) {
-            visit(item, bodyScope);
+            if (!(item instanceof DirectiveNode)) {
+                visit(item, bodyScope);
+            }
         }
 
         String name = (String) visit(node.getName(), scope);
@@ -363,6 +365,11 @@ public class NodeEvaluator implements NodeVisitor<Scope, Object, RuntimeExceptio
                 }
             });
 
+        for (Node item : node.getBody()) {
+            if (item instanceof DirectiveNode) {
+                visit(item, bodyScope);
+            }
+        }
 
         Object value = rootScope.get(typeName);
 


### PR DESCRIPTION
This is so that directive processors are guaranteed to have full and stable set of values in the scope to work with.