### PR TITLE
GYRO-281: Allow null items when mapping a glob collection.

### DIFF
--- a/core/src/main/java/gyro/core/scope/NodeEvaluator.java
+++ b/core/src/main/java/gyro/core/scope/NodeEvaluator.java
@@ -180,7 +180,6 @@ public class NodeEvaluator implements NodeVisitor<Scope, Object, RuntimeExceptio
         } else if (object instanceof GlobCollection) {
             return ((GlobCollection) object).stream()
                 .map(i -> getValue(node, i, key))
-                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
         } else if (object instanceof List) {


### PR DESCRIPTION
Filtering out nulls cause the list to be empty, but it's more accurate to return a non-empty list of nulls for the purpose of validation.