### PR TITLE
GYRO-328: Fix NPE when FileScope is relative to current directory

### DIFF
--- a/core/src/main/java/gyro/core/resource/Diffable.java
+++ b/core/src/main/java/gyro/core/resource/Diffable.java
@@ -1,5 +1,6 @@
 package gyro.core.resource;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
@@ -46,12 +47,11 @@ public abstract class Diffable {
 
     public GyroInputStream openInput(String file) {
         FileScope fileScope = scope.getFileScope();
+        Path parent = Paths.get(fileScope.getFile()).getParent();
 
-        return fileScope.getRootScope()
-            .openInput(Paths.get(fileScope.getFile())
-                .getParent()
-                .resolve(file)
-                .toString());
+        return fileScope.getRootScope().openInput(parent != null
+            ? parent.resolve(file).toString()
+            : file);
     }
 
     protected <T extends Diffable> T newSubresource(Class<T> diffableClass) {


### PR DESCRIPTION
Example is FileScope.getFile() returning "autoscaling.gyro" rather than "./autoscaling.gyro" or "/path/to/autscaling.gyro".