### PR TITLE
GYRO-329: Stops extends directive from cloning root resources.

### DIFF
--- a/core/src/main/java/gyro/core/resource/ExtendsDirectiveProcessor.java
+++ b/core/src/main/java/gyro/core/resource/ExtendsDirectiveProcessor.java
@@ -48,6 +48,11 @@ public class ExtendsDirectiveProcessor extends DirectiveProcessor<DiffableScope>
         if (value instanceof Diffable) {
             Diffable diffable = (Diffable) value;
             DiffableType<Diffable> type = DiffableType.getInstance(diffable);
+
+            if (type.isRoot()) {
+                return value;
+            }
+
             DiffableScope scope = diffable.scope;
             Diffable clone = type.newInstance(new DiffableScope(scope, null));
 


### PR DESCRIPTION
This was causing an issue when using the extends directive that referenced other root resources like securityGroups field in AWS provider's LaunchConfigurationResource. Without this, it was clone the security group and wiping out the ID.