### PR TITLE
GYRO-371: Add -merge option to @extends (defaults to false)

### DIFF
--- a/core/src/main/java/gyro/core/resource/ExtendsDirectiveProcessor.java
+++ b/core/src/main/java/gyro/core/resource/ExtendsDirectiveProcessor.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -22,6 +23,10 @@ public class ExtendsDirectiveProcessor extends DirectiveProcessor<DiffableScope>
     @SuppressWarnings("unchecked")
     public void process(DiffableScope scope, DirectiveNode node) {
         validateArguments(node, 1, 1);
+        validateOptionArguments(node, "merge", 0, 1);
+
+        boolean merge = Optional.ofNullable(getOptionArgument(scope, node, "merge", Boolean.class, 0))
+            .orElse(false);
 
         Object source = getArgument(scope, node, Object.class, 0);
         Map<String, Object> sourceMap;
@@ -53,7 +58,11 @@ public class ExtendsDirectiveProcessor extends DirectiveProcessor<DiffableScope>
                 source.getClass().getName()));
         }
 
-        sourceMap.forEach((key, value) -> scope.put(key, merge(scope.get(key), value)));
+        if (merge) {
+            sourceMap.forEach((key, value) -> scope.put(key, merge(scope.get(key), value)));
+        } else {
+            sourceMap.forEach(scope::putIfAbsent);
+        }
     }
 
     private Object merge(Object oldValue, Object newValue) {

--- a/core/src/test/java/gyro/core/resource/ExtendsDirectiveProcessorTest.java
+++ b/core/src/test/java/gyro/core/resource/ExtendsDirectiveProcessorTest.java
@@ -33,7 +33,7 @@ class ExtendsDirectiveProcessorTest {
     @Test
     void mergeList() {
         scope.put("f", ImmutableList.of(1L, 2L, 3L));
-        processor.process(scope, parse("@extends: { f: [ 4, 5 ] }"));
+        processor.process(scope, parse("@extends: { f: [ 4, 5 ] } -merge true"));
 
         assertThat(scope.get("f")).isEqualTo(ImmutableList.of(1L, 2L, 3L, 4L, 5L));
     }
@@ -41,7 +41,7 @@ class ExtendsDirectiveProcessorTest {
     @Test
     void mergeMap() {
         scope.put("f", ImmutableMap.of("key1", "value1"));
-        processor.process(scope, parse("@extends: { f: { key2: value2 } }"));
+        processor.process(scope, parse("@extends: { f: { key2: value2 } } -merge true"));
 
         assertThat(scope.get("f")).isEqualTo(ImmutableMap.of(
             "key1", "value1",
@@ -55,7 +55,7 @@ class ExtendsDirectiveProcessorTest {
                 "key1", "value1",
                 "list", ImmutableList.of(1L, 2L, 3L))));
 
-        processor.process(scope, parse("@extends: { f: { map: { key2: value2, list: [ 4, 5 ] } } }"));
+        processor.process(scope, parse("@extends: { f: { map: { key2: value2, list: [ 4, 5 ] } } } -merge true"));
 
         assertThat(scope.get("f")).isEqualTo(ImmutableMap.of(
             "map", ImmutableMap.of(


### PR DESCRIPTION
The current implementation merges maps/lists but for workflow use cases we want to override, not merge.