### PR TITLE
Adds Diffable#requires method to forcefully initialize a field

### DIFF
--- a/core/src/main/java/gyro/core/resource/Diffable.java
+++ b/core/src/main/java/gyro/core/resource/Diffable.java
@@ -76,6 +76,12 @@ public abstract class Diffable {
         return DiffableType.getInstance(diffableClass).newInternal(new DiffableScope(scope, null), null);
     }
 
+    protected void requires(String fieldName) {
+        if (!scope.isEmpty()) {
+            DiffableType.getInstance(this).getField(fieldName).setValue(this, scope.get(fieldName));
+        }
+    }
+
     public String primaryKey() {
         return String.format("%s::%s", DiffableType.getInstance(getClass()).getName(), name);
     }


### PR DESCRIPTION
Fixes #193

This pr adds a new `Diffable#requires` method which takes the name of the field that is required when initializing a different field. For example, if field `resourcePolicies` depends on the value of `region`, you could call `requires("region")` in `#setResourcePolicies` to ensure `region` has been initialized.