### PR TITLE
Add constraints to required validator

### DIFF
--- a/core/src/main/java/gyro/core/resource/DiffableField.java
+++ b/core/src/main/java/gyro/core/resource/DiffableField.java
@@ -204,4 +204,12 @@ public class DiffableField {
         return errors;
     }
 
+    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+        if (getter.isAnnotationPresent(annotationClass)) {
+            return getter.getAnnotation(annotationClass);
+        }
+
+        return null;
+    }
+
 }

--- a/core/src/main/java/gyro/core/validation/Required.java
+++ b/core/src/main/java/gyro/core/validation/Required.java
@@ -27,5 +27,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @ValidatorClass(RequiredValidator.class)
 public @interface Required {
+    enum RequiredConstraint{ONLY_ONE, AT_LEAST_ONE, REQUIRED, NOT_ALLOWED}
 
+    String when() default "";
+    String equals() default "";
+    RequiredConstraint constraint() default RequiredConstraint.REQUIRED;
 }

--- a/core/src/main/java/gyro/core/validation/RequiredValidator.java
+++ b/core/src/main/java/gyro/core/validation/RequiredValidator.java
@@ -46,8 +46,8 @@ public class RequiredValidator implements Validator<Required> {
 
                     // 'when' field is not set
                     // condition did not match
-                    // invalid if field is set
-                } else if (!ObjectUtils.isBlank(fieldValue)) {
+                    // invalid if field is set with any constraint other than NOT_ALLOWED
+                } else if (!ObjectUtils.isBlank(fieldValue) && annotation.constraint() != Required.RequiredConstraint.NOT_ALLOWED) {
                     message = String.format("Cannot be set when '%s' is not set.", annotation.when());
                     return false;
                 }
@@ -60,8 +60,8 @@ public class RequiredValidator implements Validator<Required> {
                     return isValidWithConstraint(diffable, annotation, diffableType, fieldValue);
 
                     // condition did not match
-                    // invalid if field is set
-                } else if (!ObjectUtils.isBlank(fieldValue)) {
+                    // invalid if field is set with any constraint other than NOT_ALLOWED
+                } else if (!ObjectUtils.isBlank(fieldValue) && annotation.constraint() != Required.RequiredConstraint.NOT_ALLOWED) {
                     message = String.format("Cannot be set when '%s' is not set to '%s'.", annotation.when(), annotation.equals());
                     return false;
                 }

--- a/core/src/main/java/gyro/core/validation/RequiredValidator.java
+++ b/core/src/main/java/gyro/core/validation/RequiredValidator.java
@@ -18,17 +18,116 @@ package gyro.core.validation;
 
 import com.psddev.dari.util.ObjectUtils;
 import gyro.core.resource.Diffable;
+import gyro.core.resource.DiffableField;
+import gyro.core.resource.DiffableType;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class RequiredValidator implements Validator<Required> {
 
+    private String message = null;
+
     @Override
-    public boolean isValid(Diffable diffable, Required annotation, Object value) {
-        return !ObjectUtils.isBlank(value);
+    public boolean isValid(Diffable diffable, Required annotation, Object fieldValue) {
+        message = null;
+        DiffableType<Diffable> diffableType = DiffableType.getInstance(diffable);
+        DiffableField whenField = diffableType.getField(annotation.when());
+        if (whenField != null) {
+            Object whenFieldValue = whenField.getValue(diffable);
+
+            if (ObjectUtils.isBlank(annotation.equals())) {
+                // empty 'equals' in annotation
+
+                if (!ObjectUtils.isBlank(whenFieldValue)) {
+                    // 'when' field is set
+                    // condition matched on any value of 'when' field
+                    return isValidWithConstraint(diffable, annotation, diffableType, fieldValue);
+
+                    // 'when' field is not set
+                    // condition did not match
+                    // invalid if field is set
+                } else if (!ObjectUtils.isBlank(fieldValue)) {
+                    message = String.format("Cannot be set when '%s' is not set.", annotation.when());
+                    return false;
+                }
+            } else {
+                // non empty 'equals' in annotation
+
+                if (!ObjectUtils.isBlank(whenFieldValue) && annotation.equals().equals(whenFieldValue)) {
+                    // condition matched
+                    // 'when' field value matches value in 'equals'
+                    return isValidWithConstraint(diffable, annotation, diffableType, fieldValue);
+
+                    // condition did not match
+                    // invalid if field is set
+                } else if (!ObjectUtils.isBlank(fieldValue)) {
+                    message = String.format("Cannot be set when '%s' is not set to '%s'.", annotation.when(), annotation.equals());
+                    return false;
+                }
+            }
+
+            return true;
+        } else {
+            return !ObjectUtils.isBlank(fieldValue);
+        }
     }
 
     @Override
     public String getMessage(Required annotation) {
-        return "Required";
+        return message == null ? "Required" : message;
     }
 
+    private boolean isValidWithConstraint(Diffable diffable, Required annotation, DiffableType<Diffable> diffableType, Object fieldValue) {
+        List<DiffableField> diffableFields = diffableType.getFields().stream()
+            .filter(field -> {
+                Required required = field.getAnnotation(Required.class);
+                return required != null
+                    && required.when().equals(annotation.when())
+                    && required.equals().equals(annotation.equals())
+                    && required.constraint() == annotation.constraint();
+            }).collect(Collectors.toList());
+
+        long count = diffableFields.stream().filter(field -> !ObjectUtils.isBlank(field.getValue(diffable))).count();
+
+        if (annotation.constraint() == Required.RequiredConstraint.ONLY_ONE) {
+            if (count > 1 && !ObjectUtils.isBlank(fieldValue)) {
+                // if more than one field set among the group including the field being validated
+
+                message = String.format("Only one of ['%s'] can be set.",
+                    diffableFields.stream().map(DiffableField::getName).collect(Collectors.joining("', '")));
+                return false;
+            } else if (count == 0) {
+                message = String.format("One of ['%s'] is required to be set when '%s'%s.",
+                    diffableFields.stream().map(DiffableField::getName).collect(Collectors.joining("', '")),
+                    annotation.when(),
+                    ObjectUtils.isBlank(annotation.equals()) ? "" : String.format(" is set to '%s'", annotation.equals()));
+                return false;
+            }
+        } else if (annotation.constraint() == Required.RequiredConstraint.AT_LEAST_ONE) {
+            if (count == 0) {
+                message = String.format("At least one of ['%s'] is required to be set when '%s'%s.",
+                    diffableFields.stream().map(DiffableField::getName).collect(Collectors.joining("', '")),
+                    annotation.when(),
+                    ObjectUtils.isBlank(annotation.equals()) ? "" : String.format(" is set to '%s'", annotation.equals()));
+                return false;
+            }
+        } else if (annotation.constraint() == Required.RequiredConstraint.NOT_ALLOWED) {
+            if (!ObjectUtils.isBlank(fieldValue)) {
+                message = String.format("Cannot be set when '%s'%s.",
+                    annotation.when(),
+                    ObjectUtils.isBlank(annotation.equals()) ? "" : String.format(" is set to '%s'", annotation.equals()));
+                return false;
+            }
+        } else if (annotation.constraint() == Required.RequiredConstraint.REQUIRED) {
+            if (ObjectUtils.isBlank(fieldValue)) {
+                message = String.format("Required when '%s'%s.",
+                    annotation.when(),
+                    ObjectUtils.isBlank(annotation.equals()) ? "" : String.format(" is set to '%s'", annotation.equals()));
+                return false;
+            }
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
Add params (`when`, `value`, `constraint`) to the `@Required` validator to allow finer control of validations based on dependent fields and values

This 4 constraints [`ONLY_ONE`, `AT_LEAST_ONE`, `REQUIRED` and `NOT_ALLOWED`] allows finer control of validations of fields. 

`when` specifies the field and `value` specifies the value of the field for the condition to match. if the 'value' is not specified any value of the field specified in the `when` makes the condition true.

if `when` is not specified the the annotation is treated as a regular `@Required` validator which throws an error if the field value is blank

The constraint `REQUIRED`, which is also the default mandates that the field value is required when condition is matched, and not allowed when condition not matched.

The constraint `NOT_ALLOWED` mandates that the field value cannot be set when condition is matched, ignored on condition not matched

The constraint `ONLY_ONE` checks for all the fields having the `@Required` annotation with the same `when` and `value` params. if the condition is matched, mandates that at max only one of the fields is set, and not allowed when condition is not matched

The constraint `AT_LEAST_ONE` checks for all the fields having the `@Required` annotation with the same `when` and `value` params. if the condition is matched, mandates that at least one of the fields is set, and not allowed when condition is not matched

Ex:
`@Required(when = 'field', equals = 'value', constraint = Required.RequiredConstraint.Required)`

PR having usage of this validator: https://github.com/perfectsense/gyro-google-provider/pull/56