### PR TITLE
External query results should always be external

### DIFF
--- a/core/src/main/java/gyro/core/finder/Finder.java
+++ b/core/src/main/java/gyro/core/finder/Finder.java
@@ -23,7 +23,6 @@ import com.psddev.dari.util.TypeDefinition;
 import gyro.core.auth.Credentials;
 import gyro.core.resource.DiffableType;
 import gyro.core.resource.Resource;
-import gyro.core.scope.DiffableScope;
 import gyro.core.scope.Scope;
 
 public abstract class Finder<R extends Resource> {
@@ -43,7 +42,7 @@ public abstract class Finder<R extends Resource> {
         Class<R> resourceClass = (Class<R>) TypeDefinition.getInstance(getClass())
             .getInferredGenericTypeArgumentClass(Finder.class, 0);
 
-        return DiffableType.getInstance(resourceClass).newInternal(new DiffableScope(scope, null), null);
+        return DiffableType.getInstance(resourceClass).newExternal(scope.getRootScope(), null);
     }
 
 }


### PR DESCRIPTION
Fixes #166, Fixes #153

This was causing an issue with saving state because in some instances "diffable.external" is false when it should be true. When this happens Gyro tries to generate an internal reference but doesn't have an internal name, hence the NPE.