### PR TITLE
Copy state back to pending resources after re-evaluating them

### DIFF
--- a/core/src/main/java/gyro/core/scope/NodeEvaluator.java
+++ b/core/src/main/java/gyro/core/scope/NodeEvaluator.java
@@ -541,7 +541,7 @@ public class NodeEvaluator implements NodeVisitor<Scope, Object, RuntimeExceptio
         return null;
     }
 
-    private void copy(Diffable currentResource, Diffable pendingResource) {
+    public void copy(Diffable currentResource, Diffable pendingResource) {
         if (currentResource == null) {
             return;
         }


### PR DESCRIPTION
Fixes #203 

Without this change there are situations where output values are lost during the diff triggering Gyro to try to make changes that are not needed. Further, these changes want are invalid. It tries to go from a valid value to `<output>`. The `<output>` is a placeholder but in this scenario it's never updated before calling cloud APIs causing those APIs to fail.