### PR TITLE
Fix issue with "@wait" directive not firing on workflow update actions

### DIFF
--- a/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
+++ b/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
@@ -167,7 +167,8 @@ public abstract class AbstractConfigCommand extends AbstractCommand {
                     done.incrementAndGet();
 
                     if (keep) {
-                        DiffableInternals.update(resource, true);
+                        DiffableInternals.disconnect(resource);
+                        DiffableInternals.update(resource);
                         return false;
 
                     } else {

--- a/core/src/main/java/gyro/core/diff/Diff.java
+++ b/core/src/main/java/gyro/core/diff/Diff.java
@@ -53,8 +53,8 @@ public class Diff {
             ? new ArrayList<>(pendingDiffables)
             : Collections.emptyList();
 
-        this.currentDiffables.forEach(d -> DiffableInternals.update(d, false));
-        this.pendingDiffables.forEach(d -> DiffableInternals.update(d, false));
+        this.currentDiffables.forEach(d -> DiffableInternals.update(d));
+        this.pendingDiffables.forEach(d -> DiffableInternals.update(d));
     }
 
     public Diff(Diffable currentDiffable, Diffable pendingDiffable) {
@@ -66,8 +66,8 @@ public class Diff {
             ? Collections.singletonList(pendingDiffable)
             : Collections.emptyList();
 
-        this.currentDiffables.forEach(d -> DiffableInternals.update(d, false));
-        this.pendingDiffables.forEach(d -> DiffableInternals.update(d, false));
+        this.currentDiffables.forEach(d -> DiffableInternals.update(d));
+        this.pendingDiffables.forEach(d -> DiffableInternals.update(d));
     }
 
     public List<Change> getChanges() {

--- a/core/src/main/java/gyro/core/reference/FinderReferenceResolver.java
+++ b/core/src/main/java/gyro/core/reference/FinderReferenceResolver.java
@@ -62,7 +62,7 @@ public class FinderReferenceResolver extends ReferenceResolver {
             resources = finder.findAll();
         }
 
-        resources.forEach(r -> DiffableInternals.update(r, false));
+        resources.forEach(r -> DiffableInternals.update(r));
 
         return resources;
     }

--- a/core/src/main/java/gyro/core/resource/DiffableType.java
+++ b/core/src/main/java/gyro/core/resource/DiffableType.java
@@ -238,7 +238,7 @@ public class DiffableType<D extends Diffable> {
                     String.join(", ", invalidFieldNames)));
         }
 
-        DiffableInternals.update(diffable, false);
+        DiffableInternals.update(diffable);
     }
 
     public List<ValidationError> validate(D diffable) {

--- a/core/src/main/java/gyro/core/workflow/UpdateAction.java
+++ b/core/src/main/java/gyro/core/workflow/UpdateAction.java
@@ -67,6 +67,7 @@ public class UpdateAction extends Action {
         }
 
         Resource pendingResource = (Resource) resource;
+        DiffableInternals.disconnect(pendingResource);
         DiffableScope resourceScope = DiffableInternals.getScope(pendingResource);
 
         for (Node item : body) {
@@ -74,7 +75,7 @@ public class UpdateAction extends Action {
         }
 
         DiffableType.getInstance(pendingResource).setValues(pendingResource, resourceScope);
-        DiffableInternals.update(pendingResource, true);
+        DiffableInternals.update(pendingResource);
     }
 
 }


### PR DESCRIPTION
Fixes #206 

The issue was that when `DiffableInternals.update(pendingResource, true)` is called the wait processor is lost because a new scope is created. This implementation ensures the new scope is created before the body of the update directive called, ensuring that the wait processor remains.