### PR TITLE
Bug fix/external query credentials

### DIFF
--- a/core/src/main/java/gyro/core/auth/Credentials.java
+++ b/core/src/main/java/gyro/core/auth/Credentials.java
@@ -37,7 +37,9 @@ public abstract class Credentials {
 
         String name = diffableScope != null
             ? diffableScope.getSettings(CredentialsSettings.class).getUseCredentials()
-            : scope.getRootScope().getSettings(CredentialsSettings.class).getUseCredentials();
+            : null;
+
+        name = name == null ? scope.getRootScope().getSettings(CredentialsSettings.class).getUseCredentials() : name;
 
         name = Reflections.getNamespace(contextClass) + "::" + (name != null ? name : "default");
 

--- a/core/src/main/java/gyro/core/auth/Credentials.java
+++ b/core/src/main/java/gyro/core/auth/Credentials.java
@@ -31,7 +31,6 @@ public abstract class Credentials {
 
     Scope scope;
 
-    @SuppressWarnings("unchecked")
     public static <C extends Credentials> C getInstance(Class<C> credentialsClass, Class<?> contextClass, Scope scope) {
         DiffableScope diffableScope = scope.getClosest(DiffableScope.class);
 
@@ -39,25 +38,28 @@ public abstract class Credentials {
             ? diffableScope.getSettings(CredentialsSettings.class).getUseCredentials()
             : null;
 
-        name = name == null ? scope.getRootScope().getSettings(CredentialsSettings.class).getUseCredentials() : name;
+        return getInstance(credentialsClass, contextClass, scope, name);
+    }
 
-        name = Reflections.getNamespace(contextClass) + "::" + (name != null ? name : "default");
+    @SuppressWarnings("unchecked")
+    public static <C extends Credentials> C getInstance(Class<C> credentialsClass, Class<?> contextClass, Scope scope, String credentialName) {
+        credentialName = Reflections.getNamespace(contextClass) + "::" + (credentialName != null ? credentialName : "default");
 
         Credentials credentials = scope.getRootScope()
             .getSettings(CredentialsSettings.class)
             .getCredentialsByName()
-            .get(name);
+            .get(credentialName);
 
         if (credentials == null) {
             throw new GyroException(String.format(
                 "Can't find @|bold %s|@ credentials!",
-                name));
+                credentialName));
         }
 
         if (!credentialsClass.isInstance(credentials)) {
             throw new GyroException(String.format(
                 "Can't use @|bold %s|@ credentials because it's an instance of @|bold %s|@, not @|bold %s|@!",
-                name,
+                credentialName,
                 credentials.getClass().getName(),
                 credentialsClass.getName()));
         }

--- a/core/src/main/java/gyro/core/finder/Finder.java
+++ b/core/src/main/java/gyro/core/finder/Finder.java
@@ -28,13 +28,18 @@ import gyro.core.scope.Scope;
 public abstract class Finder<R extends Resource> {
 
     Scope scope;
+    String credentials;
+
+    public void setCredentials(String credentials) {
+        this.credentials = credentials;
+    }
 
     public abstract List<R> findAll();
 
     public abstract List<R> find(Map<String, Object> filters);
 
     public <C extends Credentials> C credentials(Class<C> credentialsClass) {
-        return Credentials.getInstance(credentialsClass, getClass(), scope);
+        return Credentials.getInstance(credentialsClass, getClass(), scope, credentials);
     }
 
     public R newResource() {
@@ -42,7 +47,7 @@ public abstract class Finder<R extends Resource> {
         Class<R> resourceClass = (Class<R>) TypeDefinition.getInstance(getClass())
             .getInferredGenericTypeArgumentClass(Finder.class, 0);
 
-        return DiffableType.getInstance(resourceClass).newExternalWithCredentials(scope.getRootScope(), null);
+        return DiffableType.getInstance(resourceClass).newExternalWithCredentials(scope.getRootScope(), null, credentials);
     }
 
 }

--- a/core/src/main/java/gyro/core/reference/FinderReferenceResolver.java
+++ b/core/src/main/java/gyro/core/reference/FinderReferenceResolver.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 
 import gyro.core.GyroException;
 import gyro.core.Type;
-import gyro.core.auth.CredentialsSettings;
 import gyro.core.finder.Finder;
 import gyro.core.finder.FinderField;
 import gyro.core.finder.FinderSettings;
@@ -57,14 +56,10 @@ public class FinderReferenceResolver extends ReferenceResolver {
                 type));
         }
 
-        Optional.ofNullable(getOptionArgument(scope, node, "credentials", String.class, 0))
-            .ifPresent(o -> {
-                arguments.remove(o);
-                scope.getRootScope().getSettings(CredentialsSettings.class).setUseCredentials(o);
-            });
-
         FinderType<? extends Finder<Resource>> finderType = FinderType.getInstance(finderClass);
         Finder<Resource> finder = finderType.newInstance(scope);
+        Optional.ofNullable(getOptionArgument(scope, node, "credentials", String.class, 0))
+            .ifPresent(finder::setCredentials);
         List<Resource> resources = null;
 
         if (!arguments.isEmpty()) {

--- a/core/src/main/java/gyro/core/resource/DiffableType.java
+++ b/core/src/main/java/gyro/core/resource/DiffableType.java
@@ -159,9 +159,9 @@ public class DiffableType<D extends Diffable> {
         return diffable;
     }
 
-    public D newExternalWithCredentials(RootScope root, Object id) {
+    public D newExternalWithCredentials(RootScope root, Object id, String credentials) {
         D diffable = newExternal(root, id);
-        diffable.scope.getClosest(DiffableScope.class).getSettings(CredentialsSettings.class).setUseCredentials(root.getSettings(CredentialsSettings.class).getUseCredentials());
+        diffable.scope.getClosest(DiffableScope.class).getSettings(CredentialsSettings.class).setUseCredentials(credentials);
 
         return diffable;
     }


### PR DESCRIPTION
Fixes #251 
Fixes #252 

Instead of putting the credential in the rootScope, which causes multiple issues
 - successive external-query with credentials changes the default credential
 - looses supplied credential when external-query defined under a resource scope

Create a credential variable specifically for the external-query embedded in the Finder Class, which is directly used to create the client and put in the diffable scope of a resource as well for it to act similar to using `@uses-credentials`