### PR TITLE
Remote state backend

### DIFF
--- a/cli/src/main/java/gyro/cli/Gyro.java
+++ b/cli/src/main/java/gyro/cli/Gyro.java
@@ -32,6 +32,7 @@ import gyro.core.Abort;
 import gyro.core.GyroCore;
 import gyro.core.GyroException;
 import gyro.core.LocalFileBackend;
+import gyro.core.backend.FileBackendsSettings;
 import gyro.core.command.AbstractCommand;
 import gyro.core.command.GyroCommand;
 import gyro.core.command.GyroCommandGroup;
@@ -70,7 +71,10 @@ public class Gyro {
         try {
             Optional.ofNullable(GyroCore.getRootDirectory())
                 .map(d -> new RootScope(GyroCore.INIT_FILE, new LocalFileBackend(d), null, null))
-                .ifPresent(RootScope::load);
+                .ifPresent(r -> {
+                    r.load();
+                    GyroCore.putFileBackends(r.getSettings(FileBackendsSettings.class).getFileBackends());
+                });
 
             gyro.init(Arrays.asList(arguments));
             gyro.run();

--- a/cli/src/main/java/gyro/cli/Gyro.java
+++ b/cli/src/main/java/gyro/cli/Gyro.java
@@ -32,7 +32,7 @@ import gyro.core.Abort;
 import gyro.core.GyroCore;
 import gyro.core.GyroException;
 import gyro.core.LocalFileBackend;
-import gyro.core.backend.FileBackendsSettings;
+import gyro.core.backend.StateBackendSettings;
 import gyro.core.command.AbstractCommand;
 import gyro.core.command.GyroCommand;
 import gyro.core.command.GyroCommandGroup;
@@ -73,7 +73,7 @@ public class Gyro {
                 .map(d -> new RootScope(GyroCore.INIT_FILE, new LocalFileBackend(d), null, null))
                 .ifPresent(r -> {
                     r.load();
-                    GyroCore.putFileBackends(r.getSettings(FileBackendsSettings.class).getFileBackends());
+                    GyroCore.setStateBackend(r.getSettings(StateBackendSettings.class).getStateBackend());
                 });
 
             gyro.init(Arrays.asList(arguments));

--- a/cli/src/main/java/gyro/cli/Gyro.java
+++ b/cli/src/main/java/gyro/cli/Gyro.java
@@ -73,7 +73,7 @@ public class Gyro {
                 .map(d -> new RootScope(GyroCore.INIT_FILE, new LocalFileBackend(d), null, null))
                 .ifPresent(r -> {
                     r.load();
-                    GyroCore.setStateBackend(r.getSettings(StateBackendSettings.class).getStateBackend());
+                    GyroCore.putStateBackends(r.getSettings(StateBackendSettings.class).getStateBackends());
                 });
 
             gyro.init(Arrays.asList(arguments));

--- a/core/src/main/java/gyro/core/GyroCore.java
+++ b/core/src/main/java/gyro/core/GyroCore.java
@@ -19,8 +19,6 @@ package gyro.core;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
 
 import com.psddev.dari.util.Lazy;
 import com.psddev.dari.util.ThreadLocalStack;
@@ -28,13 +26,11 @@ import org.apache.commons.lang3.StringUtils;
 
 public class GyroCore {
 
+    private static FileBackend stateBackend;
+
     public static final String INIT_FILE = ".gyro/init.gyro";
 
-    public static final String STATE_BACKEND = "gyro-state";
-
     private static final ThreadLocalStack<GyroUI> UI = new ThreadLocalStack<>();
-
-    private static final Map<String, FileBackend> FILE_BACKEND_MAP = new HashMap<>();
 
     private static final Lazy<Path> HOME_DIRECTORY = new Lazy<Path>() {
 
@@ -76,12 +72,12 @@ public class GyroCore {
         return UI.pop();
     }
 
-    public static void putFileBackends(Map<String, FileBackend> fileBackends) {
-        fileBackends.forEach(FILE_BACKEND_MAP::put);
+    public static FileBackend getStateBackend() {
+        return stateBackend;
     }
 
-    public static FileBackend getFileBackend(String key) {
-        return FILE_BACKEND_MAP.get(key);
+    public static void setStateBackend(FileBackend stateBackend) {
+        GyroCore.stateBackend = stateBackend;
     }
 
     public static Path getHomeDirectory() {

--- a/core/src/main/java/gyro/core/GyroCore.java
+++ b/core/src/main/java/gyro/core/GyroCore.java
@@ -19,6 +19,8 @@ package gyro.core;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.psddev.dari.util.Lazy;
 import com.psddev.dari.util.ThreadLocalStack;
@@ -28,7 +30,11 @@ public class GyroCore {
 
     public static final String INIT_FILE = ".gyro/init.gyro";
 
+    public static final String STATE_BACKEND = "gyro-state";
+
     private static final ThreadLocalStack<GyroUI> UI = new ThreadLocalStack<>();
+
+    private static final Map<String, FileBackend> FILE_BACKEND_MAP = new HashMap<>();
 
     private static final Lazy<Path> HOME_DIRECTORY = new Lazy<Path>() {
 
@@ -68,6 +74,14 @@ public class GyroCore {
 
     public static GyroUI popUi() {
         return UI.pop();
+    }
+
+    public static void putFileBackends(Map<String, FileBackend> fileBackends) {
+        fileBackends.forEach(FILE_BACKEND_MAP::put);
+    }
+
+    public static FileBackend getFileBackend(String key) {
+        return FILE_BACKEND_MAP.get(key);
     }
 
     public static Path getHomeDirectory() {

--- a/core/src/main/java/gyro/core/GyroCore.java
+++ b/core/src/main/java/gyro/core/GyroCore.java
@@ -19,6 +19,9 @@ package gyro.core;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import com.psddev.dari.util.Lazy;
 import com.psddev.dari.util.ThreadLocalStack;
@@ -26,11 +29,11 @@ import org.apache.commons.lang3.StringUtils;
 
 public class GyroCore {
 
-    private static FileBackend stateBackend;
-
     public static final String INIT_FILE = ".gyro/init.gyro";
 
     private static final ThreadLocalStack<GyroUI> UI = new ThreadLocalStack<>();
+
+    private static final ConcurrentMap<String, FileBackend> STATE_BACKENDS = new ConcurrentHashMap<>();
 
     private static final Lazy<Path> HOME_DIRECTORY = new Lazy<Path>() {
 
@@ -72,12 +75,12 @@ public class GyroCore {
         return UI.pop();
     }
 
-    public static FileBackend getStateBackend() {
-        return stateBackend;
+    public static void putStateBackends(Map<String, FileBackend> stateBackends) {
+        stateBackends.forEach(STATE_BACKENDS::put);
     }
 
-    public static void setStateBackend(FileBackend stateBackend) {
-        GyroCore.stateBackend = stateBackend;
+    public static FileBackend getStateBackend(String key) {
+        return STATE_BACKENDS.get(key);
     }
 
     public static Path getHomeDirectory() {

--- a/core/src/main/java/gyro/core/LocalFileBackend.java
+++ b/core/src/main/java/gyro/core/LocalFileBackend.java
@@ -83,4 +83,19 @@ public class LocalFileBackend extends FileBackend {
         return rootDirectory.toString();
     }
 
+    public boolean deleteDirectory() {
+        return deleteDirectory(rootDirectory.toFile());
+    }
+
+    private boolean deleteDirectory(File directoryToBeDeleted) {
+        File[] allContents = directoryToBeDeleted.listFiles();
+        if (allContents != null) {
+            for (File file : allContents) {
+                deleteDirectory(file);
+            }
+        }
+
+        return directoryToBeDeleted.delete();
+    }
+
 }

--- a/core/src/main/java/gyro/core/RemoteStateBackend.java
+++ b/core/src/main/java/gyro/core/RemoteStateBackend.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.core;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.LinkedHashSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.psddev.dari.util.IoUtils;
+import gyro.util.Bug;
+
+public class RemoteStateBackend {
+
+    private FileBackend remoteBackend;
+    private LocalFileBackend localBackend;
+
+    public FileBackend getRemoteBackend() {
+        return remoteBackend;
+    }
+
+    public FileBackend getLocalBackend() {
+        return localBackend;
+    }
+
+    public RemoteStateBackend(FileBackend remoteBackend, LocalFileBackend localBackend) {
+        this.remoteBackend = remoteBackend;
+        this.localBackend = localBackend;
+    }
+
+    public boolean isLocalBackendEmpty() {
+        return list(localBackend).noneMatch(f -> f.endsWith(".gyro"));
+    }
+
+    public void deleteLocalBackend() {
+        localBackend.deleteDirectory();
+    }
+
+    public boolean copyToRemote(boolean deleteInput, boolean displayMessaging) {
+        boolean copyBackends = copyBackends(localBackend, remoteBackend, deleteInput, displayMessaging);
+
+        if (deleteInput) {
+            deleteLocalBackend();
+        }
+
+        return copyBackends;
+    }
+
+    public boolean copyToLocal(boolean deleteInput, boolean displayMessaging) {
+        boolean copyBackends = copyBackends(remoteBackend, localBackend, deleteInput, displayMessaging);
+
+        if (deleteInput) {
+            deleteLocalBackend();
+        }
+
+        return copyBackends;
+    }
+
+    private static boolean copyBackends(
+        FileBackend inputBackend,
+        FileBackend outputBackend,
+        boolean deleteInput,
+        boolean displayMessaging) {
+        GyroUI ui = GyroCore.ui();
+        LinkedHashSet<String> files = list(inputBackend)
+            .filter(f -> f.endsWith(".gyro") && !f.contains(GyroCore.INIT_FILE))
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (files.isEmpty()) {
+            if (displayMessaging) {
+                ui.write("\n@|bold,green No state files found.|@\n");
+            }
+            return false;
+        }
+
+        if (displayMessaging) {
+            files.forEach(file -> ui.write("@|green + Copy file: %s|@\n", file));
+
+            if (!ui.readBoolean(
+                Boolean.FALSE,
+                "\nAre you sure you want to copy all files? @|red This will overwrite existing files!|@")) {
+                return false;
+            }
+        }
+
+        files.forEach(file -> {
+            if (displayMessaging) {
+                ui.write("@|magenta + Copying file: %s|@\n", file);
+            }
+
+            try (OutputStream out = new GyroOutputStream(outputBackend, file)) {
+                InputStream in = new GyroInputStream(inputBackend, file);
+                IoUtils.copy(in, out);
+            } catch (IOException error) {
+                throw new Bug(error);
+            }
+
+            if (deleteInput) {
+                delete(inputBackend, file);
+            }
+        });
+
+        return true;
+    }
+
+    private static void delete(FileBackend fileBackend, String file) {
+        try {
+            fileBackend.delete(file);
+
+        } catch (Exception error) {
+            throw new GyroException(
+                String.format("Can't delete @|bold %s|@ in @|bold %s|@!", file, fileBackend),
+                error);
+        }
+    }
+
+    private static Stream<String> list(FileBackend fileBackend) {
+        try {
+            return fileBackend.list();
+
+        } catch (Exception error) {
+            throw new GyroException(
+                String.format("Can't list files in @|bold %s|@!", fileBackend),
+                error);
+        }
+    }
+}

--- a/core/src/main/java/gyro/core/backend/FileBackendDirectiveProcessor.java
+++ b/core/src/main/java/gyro/core/backend/FileBackendDirectiveProcessor.java
@@ -43,7 +43,6 @@ public class FileBackendDirectiveProcessor extends DirectiveProcessor<RootScope>
         Class<? extends FileBackend> fileBackendClass = settings.getFileBackendsClasses().get(type);
 
         FileBackend fileBackend = Reflections.newInstance(fileBackendClass);
-        fileBackend.setName(name);
 
         for (PropertyDescriptor property : Reflections.getBeanInfo(fileBackendClass).getPropertyDescriptors()) {
 
@@ -54,6 +53,9 @@ public class FileBackendDirectiveProcessor extends DirectiveProcessor<RootScope>
                     bodyScope.get(CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, property.getName()))));
             }
         }
+
+        fileBackend.setName(name);
+        fileBackend.setRootScope(scope);
         settings.getFileBackends().put(name, fileBackend);
     }
 

--- a/core/src/main/java/gyro/core/backend/StateBackendDirectiveProcessor.java
+++ b/core/src/main/java/gyro/core/backend/StateBackendDirectiveProcessor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.core.backend;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+
+import com.google.common.base.CaseFormat;
+import gyro.core.FileBackend;
+import gyro.core.GyroException;
+import gyro.core.Reflections;
+import gyro.core.Type;
+import gyro.core.directive.DirectiveProcessor;
+import gyro.core.scope.RootScope;
+import gyro.core.scope.Scope;
+import gyro.lang.ast.block.DirectiveNode;
+
+@Type("state-backend")
+public class StateBackendDirectiveProcessor extends DirectiveProcessor<RootScope> {
+
+    @Override
+    public void process(RootScope scope, DirectiveNode node) throws Exception {
+        validateArguments(node, 0, 2);
+        String type = getArgument(scope, node, String.class, 0);
+        String name = getArgument(scope, node, String.class, 1);
+
+        StateBackendSettings stateBackendSettings = scope.getSettings(StateBackendSettings.class);
+
+        if (stateBackendSettings.getStateBackend() != null
+            && !name.equals(stateBackendSettings.getStateBackend().getName())) {
+            throw new GyroException(node, "Only one 'state-backend' is allowed!");
+        }
+
+        Scope bodyScope = evaluateBody(scope, node);
+
+        FileBackendsSettings fileBackendsSettings = scope.getSettings(FileBackendsSettings.class);
+        Class<? extends FileBackend> fileBackendClass = fileBackendsSettings.getFileBackendsClasses().get(type);
+
+        FileBackend fileBackend = Reflections.newInstance(fileBackendClass);
+
+        for (PropertyDescriptor property : Reflections.getBeanInfo(fileBackendClass).getPropertyDescriptors()) {
+
+            Method setter = property.getWriteMethod();
+            if (setter != null) {
+                Reflections.invoke(setter, fileBackend, scope.convertValue(
+                    setter.getGenericParameterTypes()[0],
+                    bodyScope.get(CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, property.getName()))));
+            }
+        }
+
+        fileBackend.setName(name);
+        fileBackend.setRootScope(scope);
+        stateBackendSettings.setStateBackend(fileBackend);
+    }
+
+}

--- a/core/src/main/java/gyro/core/backend/StateBackendDirectiveProcessor.java
+++ b/core/src/main/java/gyro/core/backend/StateBackendDirectiveProcessor.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import com.google.common.base.CaseFormat;
 import gyro.core.FileBackend;
+import gyro.core.GyroException;
 import gyro.core.Reflections;
 import gyro.core.Type;
 import gyro.core.directive.DirectiveProcessor;
@@ -37,6 +38,10 @@ public class StateBackendDirectiveProcessor extends DirectiveProcessor<RootScope
         validateArguments(node, 1, 2);
         String type = getArgument(scope, node, String.class, 0);
         String name = Optional.ofNullable(getArgument(scope, node, String.class, 1)).orElse("default");
+
+        if ("local".equals(name)) {
+            throw new GyroException("'local' cannot be used as a 'state-backend' name!");
+        }
 
         StateBackendSettings stateBackendSettings = scope.getSettings(StateBackendSettings.class);
 

--- a/core/src/main/java/gyro/core/backend/StateBackendSettings.java
+++ b/core/src/main/java/gyro/core/backend/StateBackendSettings.java
@@ -16,19 +16,24 @@
 
 package gyro.core.backend;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import gyro.core.FileBackend;
 import gyro.core.scope.Settings;
 
 public class StateBackendSettings extends Settings {
 
-    private FileBackend stateBackend;
+    private Map<String, FileBackend> stateBackends;
 
-    public FileBackend getStateBackend() {
-        return stateBackend;
+    public Map<String, FileBackend> getStateBackends() {
+        if (stateBackends == null) {
+            stateBackends = new HashMap<>();
+        }
+        return stateBackends;
     }
 
-    public void setStateBackend(FileBackend stateBackend) {
-        this.stateBackend = stateBackend;
+    public void setStateBackends(Map<String, FileBackend> stateBackends) {
+        this.stateBackends = stateBackends;
     }
-
 }

--- a/core/src/main/java/gyro/core/backend/StateBackendSettings.java
+++ b/core/src/main/java/gyro/core/backend/StateBackendSettings.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.core.backend;
+
+import gyro.core.FileBackend;
+import gyro.core.scope.Settings;
+
+public class StateBackendSettings extends Settings {
+
+    private FileBackend stateBackend;
+
+    public FileBackend getStateBackend() {
+        return stateBackend;
+    }
+
+    public void setStateBackend(FileBackend stateBackend) {
+        this.stateBackend = stateBackend;
+    }
+
+}

--- a/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
+++ b/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
@@ -103,6 +103,7 @@ public abstract class AbstractConfigCommand extends AbstractCommand {
         RootScope current = new RootScope(
             "../../" + GyroCore.INIT_FILE,
             new LocalFileBackend(rootDir.resolve(".gyro/state")),
+            GyroCore.getFileBackend(GyroCore.STATE_BACKEND),
             null,
             loadFiles);
 

--- a/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
+++ b/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
@@ -102,7 +102,7 @@ public abstract class AbstractConfigCommand extends AbstractCommand {
             }
         }
 
-        RemoteStateBackend remoteStateBackend = Optional.ofNullable(GyroCore.getFileBackend(GyroCore.STATE_BACKEND))
+        RemoteStateBackend remoteStateBackend = Optional.ofNullable(GyroCore.getStateBackend())
             .map(sb -> new RemoteStateBackend(sb, new LocalFileBackend(rootDir.resolve(".gyro/.temp-state"))))
             .orElse(null);
 

--- a/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
+++ b/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
@@ -102,24 +102,24 @@ public abstract class AbstractConfigCommand extends AbstractCommand {
             }
         }
 
-        RemoteStateBackend stateBackend = Optional.ofNullable(GyroCore.getFileBackend(GyroCore.STATE_BACKEND))
+        RemoteStateBackend remoteStateBackend = Optional.ofNullable(GyroCore.getFileBackend(GyroCore.STATE_BACKEND))
             .map(sb -> new RemoteStateBackend(sb, new LocalFileBackend(rootDir.resolve(".gyro/.temp-state"))))
             .orElse(null);
 
-        if (stateBackend != null && !stateBackend.isLocalBackendEmpty()) {
+        if (remoteStateBackend != null && !remoteStateBackend.isLocalBackendEmpty()) {
             if (!GyroCore.ui().readBoolean(
                 Boolean.FALSE,
                 "\n@|bold,red Temporary state files were detected, indicating a past failure pushing to a remote backend.\nWould you like to attempt to push the files to your remote backend?|@")) {
-                stateBackend.deleteLocalBackend();
+                remoteStateBackend.deleteLocalBackend();
             } else {
-                stateBackend.copyToRemote(true, true);
+                remoteStateBackend.copyToRemote(true, true);
             }
         }
 
         RootScope current = new RootScope(
             "../../" + GyroCore.INIT_FILE,
             new LocalFileBackend(rootDir.resolve(".gyro/state")),
-            stateBackend,
+            remoteStateBackend,
             null,
             loadFiles);
 

--- a/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
+++ b/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -37,6 +38,7 @@ import gyro.core.GyroCore;
 import gyro.core.GyroException;
 import gyro.core.GyroUI;
 import gyro.core.LocalFileBackend;
+import gyro.core.RemoteStateBackend;
 import gyro.core.auth.Credentials;
 import gyro.core.auth.CredentialsSettings;
 import gyro.core.diff.ChangeProcessor;
@@ -100,10 +102,24 @@ public abstract class AbstractConfigCommand extends AbstractCommand {
             }
         }
 
+        RemoteStateBackend stateBackend = Optional.ofNullable(GyroCore.getFileBackend(GyroCore.STATE_BACKEND))
+            .map(sb -> new RemoteStateBackend(sb, new LocalFileBackend(rootDir.resolve(".gyro/.temp-state"))))
+            .orElse(null);
+
+        if (stateBackend != null && !stateBackend.isLocalBackendEmpty()) {
+            if (!GyroCore.ui().readBoolean(
+                Boolean.FALSE,
+                "\n@|bold,red Temporary state files were detected, indicating a past failure pushing to a remote backend.\nWould you like to attempt to push the files to your remote backend?|@")) {
+                stateBackend.deleteLocalBackend();
+            } else {
+                stateBackend.copyToRemote(true, true);
+            }
+        }
+
         RootScope current = new RootScope(
             "../../" + GyroCore.INIT_FILE,
             new LocalFileBackend(rootDir.resolve(".gyro/state")),
-            GyroCore.getFileBackend(GyroCore.STATE_BACKEND),
+            stateBackend,
             null,
             loadFiles);
 

--- a/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
+++ b/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
@@ -102,7 +102,7 @@ public abstract class AbstractConfigCommand extends AbstractCommand {
             }
         }
 
-        RemoteStateBackend remoteStateBackend = Optional.ofNullable(GyroCore.getStateBackend())
+        RemoteStateBackend remoteStateBackend = Optional.ofNullable(GyroCore.getStateBackend("default"))
             .map(sb -> new RemoteStateBackend(sb, new LocalFileBackend(rootDir.resolve(".gyro/.temp-state"))))
             .orElse(null);
 

--- a/core/src/main/java/gyro/core/command/StateCommandGroup.java
+++ b/core/src/main/java/gyro/core/command/StateCommandGroup.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.core.command;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class StateCommandGroup implements GyroCommandGroup {
+
+    @Override
+    public String getName() {
+        return "state";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Manage state.";
+    }
+
+    @Override
+    public List<Class<?>> getCommands() {
+        return Arrays.asList(StateCopyCommand.class);
+    }
+
+    @Override
+    public Class<?> getDefaultCommand() {
+        return StateHelp.class;
+    }
+
+}

--- a/core/src/main/java/gyro/core/command/StateCopyCommand.java
+++ b/core/src/main/java/gyro/core/command/StateCopyCommand.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.core.command;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.psddev.dari.util.IoUtils;
+import gyro.core.FileBackend;
+import gyro.core.GyroCore;
+import gyro.core.GyroException;
+import gyro.core.GyroInputStream;
+import gyro.core.GyroOutputStream;
+import gyro.core.GyroUI;
+import gyro.core.LocalFileBackend;
+import gyro.util.Bug;
+import io.airlift.airline.Command;
+import io.airlift.airline.Help;
+import io.airlift.airline.Option;
+import io.airlift.airline.model.MetadataLoader;
+
+@Command(name = "copy", description = "Copy state files between local and remote backend.")
+public class StateCopyCommand implements GyroCommand {
+
+    @Option(name = "--to-local", description = "Pull state files from a remote backend and copy to local backend")
+    private boolean toLocal;
+
+    @Option(name = "--to-remote", description = "Push state files from local backend and copy to a remote backend")
+    private boolean toRemote;
+
+    public boolean getToLocal() {
+        return toLocal;
+    }
+
+    public boolean getToRemote() {
+        return toRemote;
+    }
+
+    @Override
+    public void execute() throws Exception {
+        if ((getToLocal() && getToRemote()) || (!getToLocal() && !getToRemote())) {
+            Help.help(MetadataLoader.loadCommand(StateCopyCommand.class));
+            return;
+        }
+
+        FileBackend remoteStateBackend = GyroCore.getFileBackend(GyroCore.STATE_BACKEND);
+
+        if (remoteStateBackend == null) {
+            throw new GyroException(
+                "Could not find a 'gyro-state' file backend in the 'init.gyro'! Add a file backend with the name 'gyro-state' to copy state files to/from.");
+        }
+
+        Path rootDir = GyroCore.getRootDirectory();
+
+        if (rootDir == null) {
+            throw new GyroException(
+                "Not a gyro project directory, use 'gyro init <plugins>...' to create one. See 'gyro help init' for detailed usage.");
+        }
+
+        LocalFileBackend localStateBackend = new LocalFileBackend(rootDir.resolve(".gyro/state"));
+        boolean copiedFiles;
+
+        if (getToLocal()) {
+            GyroCore.ui().write("\n@|bold,white Looking for remote state files...|@\n\n");
+            copiedFiles = copyBackends(remoteStateBackend, localStateBackend);
+        } else {
+            GyroCore.ui().write("\n@|bold,white Looking for local state files...|@\n\n");
+            copiedFiles = copyBackends(localStateBackend, remoteStateBackend);
+        }
+
+        if (copiedFiles) {
+            GyroCore.ui().write("\n@|bold,green OK|@\n");
+        }
+    }
+
+    private static boolean copyBackends(FileBackend inputBackend, FileBackend outputBackend) {
+        LinkedHashSet<String> files = list(inputBackend)
+            .filter(f -> f.endsWith(".gyro") && !f.contains(GyroCore.INIT_FILE))
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (files.isEmpty()) {
+            GyroCore.ui().write("\n@|bold,green No state files found.|@\n");
+            return false;
+        }
+
+        GyroUI ui = GyroCore.ui();
+
+        files.forEach(file -> ui.write("@|green + Copy file: %s|@\n", file));
+
+        if (!ui.readBoolean(
+            Boolean.FALSE,
+            "\nAre you sure you want to copy all files? @|red This will overwrite existing files!|@")) {
+            return false;
+        }
+
+        files.forEach(file -> {
+            ui.write("@|magenta + Copying file: %s|@\n", file);
+            try (OutputStream out = openOutput(outputBackend, file)) {
+                InputStream in = openInput(inputBackend, file);
+                IoUtils.copy(in, out);
+            } catch (IOException error) {
+                throw new Bug(error);
+            }
+        });
+
+        return true;
+    }
+
+    private static GyroInputStream openInput(FileBackend fileBackend, String file) {
+        return new GyroInputStream(fileBackend, file);
+    }
+
+    private static GyroOutputStream openOutput(FileBackend fileBackend, String file) {
+        return new GyroOutputStream(fileBackend, file);
+    }
+
+    private static Stream<String> list(FileBackend fileBackend) {
+        try {
+            return fileBackend.list();
+
+        } catch (Exception error) {
+            throw new GyroException(
+                String.format("Can't list files in @|bold %s|@!", fileBackend),
+                error);
+        }
+    }
+}

--- a/core/src/main/java/gyro/core/command/StateCopyCommand.java
+++ b/core/src/main/java/gyro/core/command/StateCopyCommand.java
@@ -52,7 +52,7 @@ public class StateCopyCommand implements GyroCommand {
             return;
         }
 
-        FileBackend remoteBackend = GyroCore.getFileBackend(GyroCore.STATE_BACKEND);
+        FileBackend remoteBackend = GyroCore.getStateBackend();
 
         if (remoteBackend == null) {
             throw new GyroException(

--- a/core/src/main/java/gyro/core/command/StateCopyCommand.java
+++ b/core/src/main/java/gyro/core/command/StateCopyCommand.java
@@ -16,23 +16,13 @@
 
 package gyro.core.command;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.Path;
-import java.util.LinkedHashSet;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import com.psddev.dari.util.IoUtils;
 import gyro.core.FileBackend;
 import gyro.core.GyroCore;
 import gyro.core.GyroException;
-import gyro.core.GyroInputStream;
-import gyro.core.GyroOutputStream;
-import gyro.core.GyroUI;
 import gyro.core.LocalFileBackend;
-import gyro.util.Bug;
+import gyro.core.RemoteStateBackend;
 import io.airlift.airline.Command;
 import io.airlift.airline.Help;
 import io.airlift.airline.Option;
@@ -62,9 +52,9 @@ public class StateCopyCommand implements GyroCommand {
             return;
         }
 
-        FileBackend remoteStateBackend = GyroCore.getFileBackend(GyroCore.STATE_BACKEND);
+        FileBackend remoteBackend = GyroCore.getFileBackend(GyroCore.STATE_BACKEND);
 
-        if (remoteStateBackend == null) {
+        if (remoteBackend == null) {
             throw new GyroException(
                 "Could not find a 'gyro-state' file backend in the 'init.gyro'! Add a file backend with the name 'gyro-state' to copy state files to/from.");
         }
@@ -77,70 +67,19 @@ public class StateCopyCommand implements GyroCommand {
         }
 
         LocalFileBackend localStateBackend = new LocalFileBackend(rootDir.resolve(".gyro/state"));
+        RemoteStateBackend remoteStateBackend = new RemoteStateBackend(remoteBackend, localStateBackend);
         boolean copiedFiles;
 
         if (getToLocal()) {
             GyroCore.ui().write("\n@|bold,white Looking for remote state files...|@\n\n");
-            copiedFiles = copyBackends(remoteStateBackend, localStateBackend);
+            copiedFiles = remoteStateBackend.copyToLocal(false, true);
         } else {
             GyroCore.ui().write("\n@|bold,white Looking for local state files...|@\n\n");
-            copiedFiles = copyBackends(localStateBackend, remoteStateBackend);
+            copiedFiles = remoteStateBackend.copyToRemote(false, true);
         }
 
         if (copiedFiles) {
             GyroCore.ui().write("\n@|bold,green OK|@\n");
-        }
-    }
-
-    private static boolean copyBackends(FileBackend inputBackend, FileBackend outputBackend) {
-        LinkedHashSet<String> files = list(inputBackend)
-            .filter(f -> f.endsWith(".gyro") && !f.contains(GyroCore.INIT_FILE))
-            .collect(Collectors.toCollection(LinkedHashSet::new));
-
-        if (files.isEmpty()) {
-            GyroCore.ui().write("\n@|bold,green No state files found.|@\n");
-            return false;
-        }
-
-        GyroUI ui = GyroCore.ui();
-
-        files.forEach(file -> ui.write("@|green + Copy file: %s|@\n", file));
-
-        if (!ui.readBoolean(
-            Boolean.FALSE,
-            "\nAre you sure you want to copy all files? @|red This will overwrite existing files!|@")) {
-            return false;
-        }
-
-        files.forEach(file -> {
-            ui.write("@|magenta + Copying file: %s|@\n", file);
-            try (OutputStream out = openOutput(outputBackend, file)) {
-                InputStream in = openInput(inputBackend, file);
-                IoUtils.copy(in, out);
-            } catch (IOException error) {
-                throw new Bug(error);
-            }
-        });
-
-        return true;
-    }
-
-    private static GyroInputStream openInput(FileBackend fileBackend, String file) {
-        return new GyroInputStream(fileBackend, file);
-    }
-
-    private static GyroOutputStream openOutput(FileBackend fileBackend, String file) {
-        return new GyroOutputStream(fileBackend, file);
-    }
-
-    private static Stream<String> list(FileBackend fileBackend) {
-        try {
-            return fileBackend.list();
-
-        } catch (Exception error) {
-            throw new GyroException(
-                String.format("Can't list files in @|bold %s|@!", fileBackend),
-                error);
         }
     }
 }

--- a/core/src/main/java/gyro/core/command/StateHelp.java
+++ b/core/src/main/java/gyro/core/command/StateHelp.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.core.command;
+
+import java.util.Collections;
+
+import io.airlift.airline.Help;
+
+public class StateHelp extends Help {
+
+    @Override
+    public void run() {
+        help(global, Collections.singletonList("state"));
+    }
+
+}

--- a/core/src/main/java/gyro/core/command/UpCommand.java
+++ b/core/src/main/java/gyro/core/command/UpCommand.java
@@ -70,7 +70,7 @@ public class UpCommand extends AbstractConfigCommand {
                 current = new RootScope(
                     current.getFile(),
                     current.getBackend(),
-                    current.getStateBackend(),
+                    current.getRemoteStateBackend(),
                     null,
                     current.getLoadFiles());
 
@@ -100,14 +100,14 @@ public class UpCommand extends AbstractConfigCommand {
     }
 
     private void pushToRemote(RootScope current, GyroUI ui) {
-        RemoteStateBackend stateBackend = current.getStateBackend();
-        if (stateBackend != null && !stateBackend.isLocalBackendEmpty()) {
+        RemoteStateBackend remoteStateBackend = current.getRemoteStateBackend();
+        if (remoteStateBackend != null && !remoteStateBackend.isLocalBackendEmpty()) {
             ui.write(ui.isVerbose()
                 ? "@|bold,white Pushing state files to remote backend...|@"
                 : "\n@|bold,white Pushing state files to remote backend...|@");
 
             try {
-                stateBackend.copyToRemote(true, false);
+                remoteStateBackend.copyToRemote(true, false);
                 ui.write(ui.isVerbose() ? "\n@|bold,green OK|@\n\n" : "@|bold,green  OK|@\n");
 
             } catch (Exception ex) {

--- a/core/src/main/java/gyro/core/command/UpCommand.java
+++ b/core/src/main/java/gyro/core/command/UpCommand.java
@@ -66,7 +66,12 @@ public class UpCommand extends AbstractConfigCommand {
             } catch (Retry error) {
                 ui.write("\n@|bold,white Relooking for changes after workflow...\n\n|@");
 
-                current = new RootScope(current.getFile(), current.getBackend(), null, current.getLoadFiles());
+                current = new RootScope(
+                    current.getFile(),
+                    current.getBackend(),
+                    current.getStateBackend(),
+                    null,
+                    current.getLoadFiles());
 
                 current.evaluate();
 

--- a/core/src/main/java/gyro/core/scope/RootScope.java
+++ b/core/src/main/java/gyro/core/scope/RootScope.java
@@ -48,6 +48,7 @@ import gyro.core.auth.CredentialsPlugin;
 import gyro.core.auth.UsesCredentialsDirectiveProcessor;
 import gyro.core.backend.FileBackendDirectiveProcessor;
 import gyro.core.backend.FileBackendPlugin;
+import gyro.core.backend.StateBackendDirectiveProcessor;
 import gyro.core.command.HighlanderDirectiveProcessor;
 import gyro.core.command.HighlanderSettings;
 import gyro.core.control.ForDirectiveProcessor;
@@ -189,6 +190,7 @@ public class RootScope extends FileScope {
             PrintDirectiveProcessor.class,
             ReplaceDirectiveProcessor.class,
             RepositoryDirectiveProcessor.class,
+            StateBackendDirectiveProcessor.class,
             TypeDescriptionDirectiveProcessor.class,
             UpdateDirectiveProcessor.class,
             UsesCredentialsDirectiveProcessor.class,

--- a/core/src/main/java/gyro/core/scope/State.java
+++ b/core/src/main/java/gyro/core/scope/State.java
@@ -66,7 +66,12 @@ public class State {
     private Boolean removeModifiedInField;
 
     public State(RootScope current, RootScope pending, boolean test) {
-        this.root = new RootScope(current.getFile(), current.getBackend(), null, current.getLoadFiles());
+        this.root = new RootScope(
+            current.getFile(),
+            current.getBackend(),
+            current.getStateBackend(),
+            null,
+            current.getLoadFiles());
 
         root.evaluate();
 

--- a/core/src/main/java/gyro/core/scope/State.java
+++ b/core/src/main/java/gyro/core/scope/State.java
@@ -69,7 +69,7 @@ public class State {
         this.root = new RootScope(
             current.getFile(),
             current.getBackend(),
-            current.getStateBackend(),
+            current.getRemoteStateBackend(),
             null,
             current.getLoadFiles());
 

--- a/core/src/main/java/gyro/core/virtual/VirtualResourceVisitor.java
+++ b/core/src/main/java/gyro/core/virtual/VirtualResourceVisitor.java
@@ -75,7 +75,7 @@ public class VirtualResourceVisitor extends ResourceVisitor {
         RootScope virtualRoot = new RootScope(
             root.getFile(),
             root.getBackend(),
-            root.getStateBackend(),
+            root.getRemoteStateBackend(),
             new VirtualRootScope(root.getCurrent(), name),
             root.getLoadFiles());
 

--- a/core/src/main/java/gyro/core/virtual/VirtualResourceVisitor.java
+++ b/core/src/main/java/gyro/core/virtual/VirtualResourceVisitor.java
@@ -75,6 +75,7 @@ public class VirtualResourceVisitor extends ResourceVisitor {
         RootScope virtualRoot = new RootScope(
             root.getFile(),
             root.getBackend(),
+            root.getStateBackend(),
             new VirtualRootScope(root.getCurrent(), name),
             root.getLoadFiles());
 

--- a/core/src/main/java/gyro/core/virtual/VirtualRootScope.java
+++ b/core/src/main/java/gyro/core/virtual/VirtualRootScope.java
@@ -24,7 +24,7 @@ public class VirtualRootScope extends RootScope {
     private final String virtualName;
 
     public VirtualRootScope(RootScope scope, String virtualName) {
-        super(scope.getFile(), scope.getBackend(), scope.getStateBackend(), null, scope.getLoadFiles());
+        super(scope.getFile(), scope.getBackend(), scope.getRemoteStateBackend(), null, scope.getLoadFiles());
         this.virtualName = virtualName;
         putAll(scope);
         getFileScopes().addAll(scope.getFileScopes());

--- a/core/src/main/java/gyro/core/virtual/VirtualRootScope.java
+++ b/core/src/main/java/gyro/core/virtual/VirtualRootScope.java
@@ -24,7 +24,7 @@ public class VirtualRootScope extends RootScope {
     private final String virtualName;
 
     public VirtualRootScope(RootScope scope, String virtualName) {
-        super(scope.getFile(), scope.getBackend(), null, scope.getLoadFiles());
+        super(scope.getFile(), scope.getBackend(), scope.getStateBackend(), null, scope.getLoadFiles());
         this.virtualName = virtualName;
         putAll(scope);
         getFileScopes().addAll(scope.getFileScopes());


### PR DESCRIPTION
Fixes #236 and fixes #267

This PR enables users to store all state files in a remote backend. In order to use a remote backend, add a `@state-backend` to your `init.gyro`. For example, the following would store all state files in an S3 bucket named `my-gyro-state`, under the `.gyro/state` prefix:
```
@state-backend 'aws::s3'
    bucket: "my-gyro-state"
    prefix: ".gyro/state"
@end
```
This backend will be picked up by gyro, and used to ONLY store the state files. When running gyro locally, the `init.gyro` will still be in the `.gyro` directory. When running `gyro up`, all state files will first be written to a local temp directory, then pushed up to the remote directory. On success, all temp state files are deleted. On failure, the temp files will remain, and running `gyro up` again will prompt the user to retry pushing those state files.

This PR also introduces the `gyro state copy` command, which is intended to be used to migrate between backends for state:
```
gyro state copy --from <backend-name> --to <backend-name>
```
will copy all state files from the `--from` backend, and push them to the `--to` backend. `local` can be specified to copy to/from the local directory.

Note that this command doesn't delete the copied files. All files that will be copied are listed and given a confirmation prompt.