### PR TITLE
Linking project overview dashboard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Gitter](https://img.shields.io/gitter/room/perfectsense/gyro)](https://gitter.im/perfectsense/gyro)
 [![TravisCI](https://api.travis-ci.org/perfectsense/gyro.svg?branch=master)](https://travis-ci.org/perfectsense/gyro)
 [![Apache License 2.0](https://img.shields.io/github/license/perfectsense/gyro)](https://github.com/perfectsense/gyro/blob/master/LICENSE)
+[![SourceSpy Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/perfectsensegyro/)
 
 Gyro is command-line tool for creating, updating, and maintaining cloud infrastructure. Gyro makes
 infrastructure-as-code possible.


### PR DESCRIPTION
Adding a link (shield) to the README header. Dashboard describes overall project structure and dependencies. Will be useful for new developers looking to contribute to the project. Direct link: https://sourcespy.com/github/perfectsensegyro/