### PR TITLE
Implement State Locking

### DIFF
--- a/cli/src/main/java/gyro/cli/Gyro.java
+++ b/cli/src/main/java/gyro/cli/Gyro.java
@@ -32,6 +32,7 @@ import gyro.core.Abort;
 import gyro.core.GyroCore;
 import gyro.core.GyroException;
 import gyro.core.LocalFileBackend;
+import gyro.core.backend.LockBackendSettings;
 import gyro.core.backend.StateBackendSettings;
 import gyro.core.command.AbstractCommand;
 import gyro.core.command.GyroCommand;
@@ -74,6 +75,7 @@ public class Gyro {
                 .ifPresent(r -> {
                     r.load();
                     GyroCore.putStateBackends(r.getSettings(StateBackendSettings.class).getStateBackends());
+                    GyroCore.pushLockBackend(r.getSettings(LockBackendSettings.class).getLockBackend());
                 });
 
             gyro.init(Arrays.asList(arguments));
@@ -89,6 +91,7 @@ public class Gyro {
 
         } finally {
             GyroCore.popUi();
+            GyroCore.popLockBackend();
         }
     }
 

--- a/core/src/main/java/gyro/core/GyroCore.java
+++ b/core/src/main/java/gyro/core/GyroCore.java
@@ -33,6 +33,8 @@ public class GyroCore {
 
     private static final ThreadLocalStack<GyroUI> UI = new ThreadLocalStack<>();
 
+    private static final ThreadLocalStack<LockBackend> LOCK_BACKENDS = new ThreadLocalStack<>();
+
     private static final ConcurrentMap<String, FileBackend> STATE_BACKENDS = new ConcurrentHashMap<>();
 
     private static final Lazy<Path> HOME_DIRECTORY = new Lazy<Path>() {
@@ -75,6 +77,20 @@ public class GyroCore {
         return UI.pop();
     }
 
+    public static LockBackend getLockBackend() {
+        return LOCK_BACKENDS.get();
+    }
+
+    public static void pushLockBackend(LockBackend lockBackend) {
+        if (lockBackend != null) {
+            LOCK_BACKENDS.push(lockBackend);
+        }
+    }
+
+    public static LockBackend popLockBackend() {
+        return LOCK_BACKENDS.pop();
+    }
+
     public static void putStateBackends(Map<String, FileBackend> stateBackends) {
         stateBackends.forEach(STATE_BACKENDS::put);
     }
@@ -90,5 +106,4 @@ public class GyroCore {
     public static Path getRootDirectory() {
         return ROOT_DIRECTORY.get();
     }
-
 }

--- a/core/src/main/java/gyro/core/LocalFileBackend.java
+++ b/core/src/main/java/gyro/core/LocalFileBackend.java
@@ -98,4 +98,7 @@ public class LocalFileBackend extends FileBackend {
         return directoryToBeDeleted.delete();
     }
 
+    public boolean fileExists(String file) {
+        return Files.exists(rootDirectory.resolve(file));
+    }
 }

--- a/core/src/main/java/gyro/core/LockBackend.java
+++ b/core/src/main/java/gyro/core/LockBackend.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.core;
+
+import gyro.core.scope.RootScope;
+
+public abstract class LockBackend {
+
+    public static final String TEMP_LOCK_ID_FILE = "TempLockId.txt";
+
+    private RootScope rootScope;
+    private String lockId;
+    private Boolean stayLocked;
+
+    public RootScope getRootScope() {
+        return rootScope;
+    }
+
+    public void setRootScope(RootScope rootScope) {
+        this.rootScope = rootScope;
+    }
+
+    public String getLockId() {
+        return lockId;
+    }
+
+    public void setLockId(String lockId) {
+        this.lockId = lockId;
+    }
+
+    public boolean stayLocked() {
+        return Boolean.TRUE.equals(stayLocked);
+    }
+
+    public void setStayLocked(Boolean stayLocked) {
+        this.stayLocked = stayLocked;
+    }
+
+    /**
+     * Attempts to lock the state. Throw an exception in the case of already locked. The exception message should contain the new lock ID so that users can forcefully unlock if they want.
+     */
+    public abstract void lock(String lockId) throws Exception;
+
+    /**
+     * Attempts to unlock the state. Throw an exception in the case of {@param lockId} no longer being the active lock.
+     */
+    public abstract void unlock(String lockId) throws Exception;
+
+    /**
+     * Sets the lock info on the {@param lockId}. Throw an exception in the case of {@param lockId} no longer being the active lock.
+     */
+    public abstract void updateLockInfo(String lockId, String info) throws Exception;
+
+    public void lock() throws Exception {
+        lock(getLockId());
+    }
+
+    public void unlock() throws Exception {
+        unlock(getLockId());
+    }
+
+    public void updateLockInfo(String info) throws Exception {
+        updateLockInfo(getLockId(), info);
+    }
+}

--- a/core/src/main/java/gyro/core/RemoteStateBackend.java
+++ b/core/src/main/java/gyro/core/RemoteStateBackend.java
@@ -16,12 +16,6 @@
 
 package gyro.core;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.util.stream.Collectors;
-
 import gyro.core.command.StateCopyCommand;
 
 public class RemoteStateBackend {
@@ -54,44 +48,6 @@ public class RemoteStateBackend {
 
     public void deleteLocalBackend() {
         localBackend.deleteDirectory();
-    }
-
-    public void writeLocal(String fileName, String contents) {
-        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(localBackend.openOutput(fileName)))) {
-            writer.write(contents);
-        } catch (Exception error) {
-            throw new GyroException(
-                String.format("Can't write @|bold %s|@ in @|bold %s|@!", fileName, localBackend),
-                error);
-        }
-    }
-
-    public String readLocal(String fileName) {
-        if (!localBackend.fileExists(fileName)) {
-            return null;
-        }
-
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(localBackend.openInput(fileName)))) {
-            return reader.lines().collect(Collectors.joining("\n"));
-        } catch (Exception error) {
-            throw new GyroException(
-                String.format("Can't read @|bold %s|@ in @|bold %s|@!", fileName, localBackend),
-                error);
-        }
-    }
-
-    public void deleteLocal(String fileName) {
-        try {
-            localBackend.delete(fileName);
-
-            if (isLocalBackendEmpty()) {
-                deleteLocalBackend();
-            }
-        } catch (Exception error) {
-            throw new GyroException(
-                String.format("Can't delete @|bold %s|@ in @|bold %s|@!", fileName, localBackend),
-                error);
-        }
     }
 
     public void copyToRemote(boolean deleteInput, boolean displayMessaging) {

--- a/core/src/main/java/gyro/core/RemoteStateBackend.java
+++ b/core/src/main/java/gyro/core/RemoteStateBackend.java
@@ -16,6 +16,12 @@
 
 package gyro.core;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.stream.Collectors;
+
 import gyro.core.command.StateCopyCommand;
 
 public class RemoteStateBackend {
@@ -48,6 +54,44 @@ public class RemoteStateBackend {
 
     public void deleteLocalBackend() {
         localBackend.deleteDirectory();
+    }
+
+    public void writeLocal(String fileName, String contents) {
+        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(localBackend.openOutput(fileName)))) {
+            writer.write(contents);
+        } catch (Exception error) {
+            throw new GyroException(
+                String.format("Can't write @|bold %s|@ in @|bold %s|@!", fileName, localBackend),
+                error);
+        }
+    }
+
+    public String readLocal(String fileName) {
+        if (!localBackend.fileExists(fileName)) {
+            return null;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(localBackend.openInput(fileName)))) {
+            return reader.lines().collect(Collectors.joining("\n"));
+        } catch (Exception error) {
+            throw new GyroException(
+                String.format("Can't read @|bold %s|@ in @|bold %s|@!", fileName, localBackend),
+                error);
+        }
+    }
+
+    public void deleteLocal(String fileName) {
+        try {
+            localBackend.delete(fileName);
+
+            if (isLocalBackendEmpty()) {
+                deleteLocalBackend();
+            }
+        } catch (Exception error) {
+            throw new GyroException(
+                String.format("Can't delete @|bold %s|@ in @|bold %s|@!", fileName, localBackend),
+                error);
+        }
     }
 
     public void copyToRemote(boolean deleteInput, boolean displayMessaging) {

--- a/core/src/main/java/gyro/core/backend/LockBackendDirectiveProcessor.java
+++ b/core/src/main/java/gyro/core/backend/LockBackendDirectiveProcessor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.core.backend;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+
+import com.google.common.base.CaseFormat;
+import gyro.core.LockBackend;
+import gyro.core.Reflections;
+import gyro.core.Type;
+import gyro.core.directive.DirectiveProcessor;
+import gyro.core.scope.RootScope;
+import gyro.core.scope.Scope;
+import gyro.lang.ast.block.DirectiveNode;
+
+@Type("lock-backend")
+public class LockBackendDirectiveProcessor extends DirectiveProcessor<RootScope> {
+
+    @Override
+    public void process(RootScope scope, DirectiveNode node) throws Exception {
+        validateArguments(node, 0, 1);
+        String type = getArgument(scope, node, String.class, 0);
+
+        LockBackendSettings settings = scope.getSettings(LockBackendSettings.class);
+        if (settings.getLockBackend() != null) {
+            return;
+        }
+
+        Scope bodyScope = evaluateBody(scope, node);
+
+        Class<? extends LockBackend> lockBackendClass = settings.getLockBackendClasses().get(type);
+
+        LockBackend lockBackend = Reflections.newInstance(lockBackendClass);
+
+        for (PropertyDescriptor property : Reflections.getBeanInfo(lockBackendClass).getPropertyDescriptors()) {
+
+            Method setter = property.getWriteMethod();
+            if (setter != null) {
+                Reflections.invoke(setter, lockBackend, scope.convertValue(
+                    setter.getGenericParameterTypes()[0],
+                    bodyScope.get(CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, property.getName()))));
+            }
+        }
+
+        lockBackend.setRootScope(scope);
+
+        settings.setLockBackend(lockBackend);
+    }
+
+}

--- a/core/src/main/java/gyro/core/backend/LockBackendPlugin.java
+++ b/core/src/main/java/gyro/core/backend/LockBackendPlugin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.core.backend;
+
+import gyro.core.LockBackend;
+import gyro.core.Reflections;
+import gyro.core.plugin.Plugin;
+import gyro.core.scope.RootScope;
+
+public class LockBackendPlugin extends Plugin {
+
+    @Override
+    public void onEachClass(RootScope root, Class<?> aClass) {
+        if (LockBackend.class.isAssignableFrom(aClass)) {
+            @SuppressWarnings("unchecked")
+            Class<? extends LockBackend> lockBackendClass = (Class<? extends LockBackend>) aClass;
+            String namespace = Reflections.getNamespace(lockBackendClass);
+            String type = Reflections.getType(lockBackendClass);
+
+            root.getSettings(LockBackendSettings.class)
+                .getLockBackendClasses()
+                .put(namespace + "::" + type, lockBackendClass);
+        }
+    }
+
+}

--- a/core/src/main/java/gyro/core/backend/LockBackendSettings.java
+++ b/core/src/main/java/gyro/core/backend/LockBackendSettings.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.core.backend;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import gyro.core.LockBackend;
+import gyro.core.scope.Settings;
+
+public class LockBackendSettings extends Settings {
+
+    private Map<String, Class<? extends LockBackend>> lockBackendClasses;
+    private LockBackend lockBackend;
+
+    public Map<String, Class<? extends LockBackend>> getLockBackendClasses() {
+        if (lockBackendClasses == null) {
+            lockBackendClasses = new HashMap<>();
+        }
+        return lockBackendClasses;
+    }
+
+    public void setLockBackendClass(Map<String, Class<? extends LockBackend>> lockBackendClasses) {
+        this.lockBackendClasses = lockBackendClasses;
+    }
+
+    public LockBackend getLockBackend() {
+        return lockBackend;
+    }
+
+    public void setLockBackend(LockBackend lockBackend) {
+        this.lockBackend = lockBackend;
+    }
+
+}

--- a/core/src/main/java/gyro/core/command/StateCommandGroup.java
+++ b/core/src/main/java/gyro/core/command/StateCommandGroup.java
@@ -33,7 +33,7 @@ public class StateCommandGroup implements GyroCommandGroup {
 
     @Override
     public List<Class<?>> getCommands() {
-        return Arrays.asList(StateCopyCommand.class);
+        return Arrays.asList(StateCopyCommand.class, StateForceUnlockCommand.class);
     }
 
     @Override

--- a/core/src/main/java/gyro/core/command/StateForceUnlockCommand.java
+++ b/core/src/main/java/gyro/core/command/StateForceUnlockCommand.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.core.command;
+
+import gyro.core.GyroCore;
+import gyro.core.GyroException;
+import gyro.core.LockBackend;
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+
+@Command(name = "force-unlock", description = "Forcefully unlock the current lock. Must pass the ID of the lock.")
+public class StateForceUnlockCommand implements GyroCommand {
+
+    @Option(name = "--lock-id", description = "The ID of the current lock you wish to unlock", required = true)
+    private String lockId;
+
+    @Override
+    public void execute() throws Exception {
+        LockBackend lockBackend = GyroCore.getLockBackend();
+
+        if (lockBackend == null) {
+            throw new GyroException("Cannot find a lock backend configured in 'init.gyro'!");
+        }
+
+        lockBackend.unlock(lockId);
+
+        GyroCore.ui().write("\n@|bold,green State unlocked.|@\n");
+    }
+}

--- a/core/src/main/java/gyro/core/command/UpCommand.java
+++ b/core/src/main/java/gyro/core/command/UpCommand.java
@@ -16,6 +16,8 @@
 
 package gyro.core.command;
 
+import java.util.Optional;
+
 import gyro.core.GyroCore;
 import gyro.core.GyroUI;
 import gyro.core.RemoteStateBackend;
@@ -113,6 +115,8 @@ public class UpCommand extends AbstractConfigCommand {
             } catch (Exception ex) {
                 ui.write("\n\n@|red Error pushing state files to remote: |@" + ex.getMessage()
                     + "\n\n@|red Run 'gyro up' again to retry.\n\n|@");
+
+                Optional.ofNullable(GyroCore.getLockBackend()).ifPresent(l -> l.setStayLocked(true));
             }
         }
     }

--- a/core/src/main/java/gyro/core/scope/RootScope.java
+++ b/core/src/main/java/gyro/core/scope/RootScope.java
@@ -48,6 +48,8 @@ import gyro.core.auth.CredentialsPlugin;
 import gyro.core.auth.UsesCredentialsDirectiveProcessor;
 import gyro.core.backend.FileBackendDirectiveProcessor;
 import gyro.core.backend.FileBackendPlugin;
+import gyro.core.backend.LockBackendDirectiveProcessor;
+import gyro.core.backend.LockBackendPlugin;
 import gyro.core.backend.StateBackendDirectiveProcessor;
 import gyro.core.command.HighlanderDirectiveProcessor;
 import gyro.core.command.HighlanderSettings;
@@ -161,6 +163,7 @@ public class RootScope extends FileScope {
             new FileBackendPlugin(),
             new FinderPlugin(),
             new GlobalChangePlugin(),
+            new LockBackendPlugin(),
             new ModificationPlugin(),
             new ReferencePlugin(),
             new ResourcePlugin(),
@@ -185,6 +188,7 @@ public class RootScope extends FileScope {
             HighlanderDirectiveProcessor.class,
             IfDirectiveProcessor.class,
             LogDirectiveProcessor.class,
+            LockBackendDirectiveProcessor.class,
             MetadataDirectiveProcessor.class,
             PluginDirectiveProcessor.class,
             PrintDirectiveProcessor.class,


### PR DESCRIPTION
Fixes #269 

This PR introduces a new abstract `LockBackend` class that should be implemented in specific providers (eg. `DynamoDbLockBackend`). Each `LockBackend` has three methods to implement: `lock`, `unlock`, and `updateLockInfo`. When first locking, the `lock` method will set a lock ID on the lock, so that way `unlock` and `updateLockInfo` can always ensure they are modifying the intended lock. There is now a `state force-unlock --lock-id <lock-id>` command that uses a lock ID to ensure only unlocking the intended lock.

At a high level, locking should behave as follows:
* User 1 runs `gyro up`, when state is currently unlocked
* `lock` gets called, now making User 1 the only user who can modify state
* `updateLockInfo` gets called, passing the user's name, the command run, and the time
* User 2 attempts to run `gyro up` while user 1 still holds the lock
* User 2 receives an error message saying locked, with the lock ID as well as the lock info
* User 2 must now wait until user 1 has finished in order to run `gyro up`
  * If user 2 is certain user 1 errored and somehow didn't unlock (very unlikely), they may use the `force-unlock` command with the lock ID they saw earlier

Here are a few edge cases, as well as the way I have addressed them:
* Two people try to lock at same time
    * Up to implemention, eg. `DyanmoDB#PutItem` condition expression should prevent
* Someone tries to `up` while lock is held
    * `LockBackend#lock()` should throw an error with current lock ID
    * `force-unlock` will allow user to unlock if desired
* An exception while holding lock is thrown during validation, creation, etc.
    * `try…finally` in `AbstractConfigCommand` should always unlock (unless exception pushing to state)
* User fails pushing to state while holding lock
    * Lock isn't unlocked
    * Temp file written with current lock id
    * Next gyro up attempts to unlock with temp file