### PR TITLE
Enable getting virtual root scope name

### DIFF
--- a/core/src/main/java/gyro/core/virtual/VirtualRootScope.java
+++ b/core/src/main/java/gyro/core/virtual/VirtualRootScope.java
@@ -75,4 +75,7 @@ public class VirtualRootScope extends RootScope {
         throw new UnsupportedOperationException();
     }
 
+    public String getVirtualName() {
+        return virtualName;
+    }
 }


### PR DESCRIPTION
This is a dependency for https://github.com/perfectsense/gyro-brightspot-plugin/pull/36