### PR TITLE
Pass single line metadata to auditor

### DIFF
--- a/core/src/main/java/gyro/core/audit/GyroAuditableUI.java
+++ b/core/src/main/java/gyro/core/audit/GyroAuditableUI.java
@@ -33,8 +33,8 @@ public abstract class GyroAuditableUI implements GyroUI {
 
     public abstract String doReplace(String message, Object... arguments);
 
-    public void finishAuditors(Map<String, Object> log) {
-        finishAuditors(log, false);
+    public void finishAuditors() {
+        finishAuditors(null, false);
     }
 
     @Override
@@ -76,7 +76,7 @@ public abstract class GyroAuditableUI implements GyroUI {
                     throw new GyroException(ex.getMessage());
                 }
             });
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> finishAuditors(log)));
+        Runtime.getRuntime().addShutdownHook(new Thread(this::finishAuditors));
         flushPendingWrites();
     }
 

--- a/core/src/main/java/gyro/core/audit/GyroAuditableUI.java
+++ b/core/src/main/java/gyro/core/audit/GyroAuditableUI.java
@@ -33,8 +33,8 @@ public abstract class GyroAuditableUI implements GyroUI {
 
     public abstract String doReplace(String message, Object... arguments);
 
-    public void finishAuditors() {
-        finishAuditors(null, false);
+    public void finishAuditors(Map<String, Object> log) {
+        finishAuditors(log, false);
     }
 
     @Override
@@ -76,7 +76,7 @@ public abstract class GyroAuditableUI implements GyroUI {
                     throw new GyroException(ex.getMessage());
                 }
             });
-        Runtime.getRuntime().addShutdownHook(new Thread(this::finishAuditors));
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> finishAuditors(log)));
         flushPendingWrites();
     }
 

--- a/core/src/main/java/gyro/core/audit/MetadataDirectiveProcessor.java
+++ b/core/src/main/java/gyro/core/audit/MetadataDirectiveProcessor.java
@@ -39,6 +39,7 @@ import gyro.lang.ast.value.ValueNode;
 @Type("metadata")
 public class MetadataDirectiveProcessor extends DirectiveProcessor<DiffableScope> {
 
+    private static final String METADATA_KEY = "METADATA_KEY";
     private static final Map<String, Map<String, Map<String, Object>>> METADATA_BY_WORKFLOW = new ConcurrentHashMap<>();
 
     public static Map<String, Object> getMetadata() {
@@ -96,11 +97,11 @@ public class MetadataDirectiveProcessor extends DirectiveProcessor<DiffableScope
 
                 if (existingMetadata != null) {
                     if (metadata.isEmpty()) {
-                        Set<Object> objects = existingMetadata.containsKey("VALUE")
-                            ? (Set<Object>) existingMetadata.get("VALUE")
+                        Set<Object> objects = existingMetadata.containsKey(METADATA_KEY)
+                            ? (Set<Object>) existingMetadata.get(METADATA_KEY)
                             : new HashSet<>();
                         objects.add(getArgument(scope, node, String.class, 0));
-                        existingMetadata.put("VALUE", objects);
+                        existingMetadata.put(METADATA_KEY, objects);
                     }
                     existingMetadata.putAll(metadata);
                 }

--- a/core/src/main/java/gyro/core/audit/MetadataDirectiveProcessor.java
+++ b/core/src/main/java/gyro/core/audit/MetadataDirectiveProcessor.java
@@ -17,8 +17,10 @@
 package gyro.core.audit;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import gyro.core.GyroException;
@@ -93,6 +95,13 @@ public class MetadataDirectiveProcessor extends DirectiveProcessor<DiffableScope
                 Map<String, Object> existingMetadata = finalStageMetadata.putIfAbsent(stageName, metadata);
 
                 if (existingMetadata != null) {
+                    if (metadata.isEmpty()) {
+                        Set<Object> objects = existingMetadata.containsKey("VALUE")
+                            ? (Set<Object>) existingMetadata.get("VALUE")
+                            : new HashSet<>();
+                        objects.add(getArgument(scope, node, String.class, 0));
+                        existingMetadata.put("VALUE", objects);
+                    }
                     existingMetadata.putAll(metadata);
                 }
             });


### PR DESCRIPTION
Fixes: #306 

As the log returned by the audit is in the form of a map, a constant key `METADATA_KEY` is where all the values will reside.
So where ever a one liner  like `@audit::metadata: <value>` is used, the `<value>` will be saved as part of the key `METADATA_KEY`