### PR TITLE
Fix: Error on finders if the resource does not have a field with @Id annotation

### DIFF
--- a/core/src/main/java/gyro/core/resource/DiffableType.java
+++ b/core/src/main/java/gyro/core/resource/DiffableType.java
@@ -43,6 +43,7 @@ import gyro.core.validation.ValidationError;
 import gyro.core.workflow.ModifiedIn;
 import gyro.lang.ast.Node;
 import gyro.parser.antlr4.GyroParser;
+import gyro.util.Bug;
 
 public class DiffableType<D extends Diffable> {
 
@@ -156,7 +157,12 @@ public class DiffableType<D extends Diffable> {
         diffable.external = true;
         diffable.scope = new DiffableScope(root, null);
 
+        if (idField == null) {
+            throw new Bug(String.format("%s is missing having @Id annotation on its reference field.", diffableClass.getName()));
+        }
+
         idField.setValue(diffable, id);
+
         return diffable;
     }
 

--- a/core/src/main/java/gyro/core/resource/DiffableType.java
+++ b/core/src/main/java/gyro/core/resource/DiffableType.java
@@ -158,7 +158,7 @@ public class DiffableType<D extends Diffable> {
         diffable.scope = new DiffableScope(root, null);
 
         if (idField == null) {
-            throw new Bug(String.format("%s is missing having @Id annotation on its reference field.", diffableClass.getName()));
+            throw new Bug(String.format("%s is missing @Id annotation.", diffableClass.getName()));
         }
 
         idField.setValue(diffable, id);


### PR DESCRIPTION
Fixes #334 

Missing @id field results in a NPE which is a bit ambiguous.

This detects if the @id annotation is missing and throws a gyro bug stating the resource and the missing annotation