### PR TITLE
Implement @timeout directive

### DIFF
--- a/core/src/main/java/gyro/core/TimeoutDirectiveProcessor.java
+++ b/core/src/main/java/gyro/core/TimeoutDirectiveProcessor.java
@@ -1,0 +1,39 @@
+package gyro.core;
+
+import com.psddev.dari.util.ObjectUtils;
+import gyro.core.directive.DirectiveProcessor;
+import gyro.core.scope.DiffableScope;
+import gyro.core.scope.Scope;
+import gyro.lang.ast.block.DirectiveNode;
+
+@Type("timeout")
+public class TimeoutDirectiveProcessor extends DirectiveProcessor<DiffableScope> {
+
+    @Override
+    public void process(DiffableScope diffableScope, DirectiveNode node) throws Exception {
+        Scope bodyScope = evaluateBody(diffableScope, node);
+
+        TimeoutSettings settings = diffableScope.getSettings(TimeoutSettings.class);
+
+        TimeoutSettings.Action action = ObjectUtils.to(TimeoutSettings.Action.class, bodyScope.get("action"));
+
+        if (action == null) {
+            throw new GyroException(node, "action field is required on @timeout directive.");
+        }
+
+        TimeoutSettings.Timeout timeout = new TimeoutSettings.Timeout();
+
+        timeout.setAtMost(ObjectUtils.to(String.class, bodyScope.get("at-most")));
+        timeout.setCheckEvery(ObjectUtils.to(String.class, bodyScope.get("check-every")));
+
+        if (bodyScope.containsKey("prompt")) {
+            timeout.setPrompt(ObjectUtils.to(Boolean.class, bodyScope.get("prompt")));
+        }
+
+        if (bodyScope.containsKey("skip")) {
+            timeout.setSkip(ObjectUtils.to(Boolean.class, bodyScope.get("skip")));
+        }
+
+        settings.getTimeouts().put(action, timeout);
+    }
+}

--- a/core/src/main/java/gyro/core/TimeoutDirectiveProcessor.java
+++ b/core/src/main/java/gyro/core/TimeoutDirectiveProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021, Brightspot.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gyro.core;
 
 import com.psddev.dari.util.ObjectUtils;

--- a/core/src/main/java/gyro/core/TimeoutSettings.java
+++ b/core/src/main/java/gyro/core/TimeoutSettings.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021, Brightspot.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gyro.core;
 
 import java.time.Duration;

--- a/core/src/main/java/gyro/core/TimeoutSettings.java
+++ b/core/src/main/java/gyro/core/TimeoutSettings.java
@@ -1,0 +1,79 @@
+package gyro.core;
+
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.EnumMap;
+import java.util.Map;
+
+import com.google.common.base.Preconditions;
+import gyro.core.scope.Settings;
+
+public class TimeoutSettings extends Settings {
+
+    private final Map<Action, Timeout> timeouts = new EnumMap<>(Action.class);
+
+    public Map<Action, Timeout> getTimeouts() {
+        return timeouts;
+    }
+
+    public static class Timeout {
+
+        private Long atMostDuration;
+        private Long checkEveryDuration;
+        private Boolean prompt;
+        private Boolean skip;
+
+        public void setAtMost(String duration) {
+            if (duration != null) {
+                atMostDuration = parse(duration);
+            }
+        }
+
+        public Long getAtMostDuration() {
+            return atMostDuration;
+        }
+
+        public void setCheckEvery(String duration) {
+            if (duration != null) {
+                checkEveryDuration = parse(duration);
+            }
+        }
+
+        public Long getCheckEveryDuration() {
+            return checkEveryDuration;
+        }
+
+        public Boolean isPrompt() {
+            return prompt;
+        }
+
+        public void setPrompt(Boolean prompt) {
+            this.prompt = prompt;
+        }
+
+        public Boolean isSkip() {
+            return skip;
+        }
+
+        public void setSkip(Boolean skip) {
+            this.skip = skip;
+        }
+
+        private long parse(String duration) {
+            Preconditions.checkNotNull(duration);
+
+            try {
+                duration = (duration.startsWith("PT") ? duration : "PT" + duration).toUpperCase();
+
+                return Duration.parse(duration).getSeconds();
+            } catch (DateTimeParseException ex) {
+                throw new GyroException("Time format '" + duration + "' is invalid.");
+            }
+        }
+
+    }
+
+    public static enum Action {
+        CREATE, UPDATE, DELETE;
+    }
+}

--- a/core/src/main/java/gyro/core/Waiter.java
+++ b/core/src/main/java/gyro/core/Waiter.java
@@ -69,21 +69,25 @@ public class Waiter {
 
     public Waiter atMost(long duration, TimeUnit unit) {
         this.atMost = unit.toMillis(duration);
+
         return this;
     }
 
     public Waiter checkEvery(long duration, TimeUnit unit) {
         this.checkEvery = unit.toMillis(duration);
+
         return this;
     }
 
     public Waiter prompt(boolean prompt) {
         this.prompt = prompt;
+
         return this;
     }
 
     public Waiter skip(boolean skip) {
         this.skip = skip;
+
         return this;
     }
 

--- a/core/src/main/java/gyro/core/Waiter.java
+++ b/core/src/main/java/gyro/core/Waiter.java
@@ -44,6 +44,10 @@ public class Waiter {
             .getTimeouts()
             .get(action);
 
+        if (timeout == null) {
+            return this;
+        }
+
         if (timeout.getAtMostDuration() != null) {
             atMost(timeout.getAtMostDuration(), TimeUnit.SECONDS);
         }

--- a/core/src/main/java/gyro/core/scope/RootScope.java
+++ b/core/src/main/java/gyro/core/scope/RootScope.java
@@ -42,6 +42,7 @@ import gyro.core.GyroOutputStream;
 import gyro.core.LogDirectiveProcessor;
 import gyro.core.PrintDirectiveProcessor;
 import gyro.core.RemoteStateBackend;
+import gyro.core.TimeoutDirectiveProcessor;
 import gyro.core.audit.AuditorDirectiveProcessor;
 import gyro.core.audit.AuditorPlugin;
 import gyro.core.audit.MetadataDirectiveProcessor;
@@ -199,6 +200,7 @@ public class RootScope extends FileScope {
             ReplaceDirectiveProcessor.class,
             RepositoryDirectiveProcessor.class,
             StateBackendDirectiveProcessor.class,
+            TimeoutDirectiveProcessor.class,
             TypeDescriptionDirectiveProcessor.class,
             UpdateDirectiveProcessor.class,
             UsesCredentialsDirectiveProcessor.class,


### PR DESCRIPTION
This directive is intended to be used with Waiter.resourceOverrides() to allow users to override the default timeouts during resource calls.

Fixes #352 