### PR TITLE
Allow Gyro commands to throw exception that displays help message of the command

### DIFF
--- a/cli/src/main/java/gyro/cli/Gyro.java
+++ b/cli/src/main/java/gyro/cli/Gyro.java
@@ -95,7 +95,7 @@ public class Gyro {
         } catch (Throwable error) {
             exitStatus = 1;
             GyroCore.ui().write("\n");
-            writeError(error);
+            writeError(error, null);
             GyroCore.ui().write("\n");
 
         } finally {
@@ -105,7 +105,7 @@ public class Gyro {
         }
     }
 
-    private static void writeError(Throwable error) {
+    private static void writeError(Throwable error, CommandLine commandLine) {
         if (error instanceof Defer) {
             ((Defer) error).write(GyroCore.ui());
 
@@ -123,7 +123,12 @@ public class Gyro {
 
             if (cause != null) {
                 GyroCore.ui().write("\n@|red Caused by:|@ ");
-                writeError(cause);
+                writeError(cause, null);
+            }
+
+            if (commandLine != null && ((GyroException) error).showHelp()) {
+                GyroCore.ui().write("\n\n");
+                commandLine.usage(commandLine.getOut());
             }
 
         } else if (error instanceof SyntaxErrorException) {
@@ -236,7 +241,7 @@ public class Gyro {
 
     // custom handler for invalid input
     private static int invalidUserInput(Exception error, CommandLine commandLine, CommandLine.ParseResult parseResult) {
-        writeError(error);
+        writeError(error, commandLine);
         return 2;
     }
 

--- a/core/src/main/java/gyro/core/GyroException.java
+++ b/core/src/main/java/gyro/core/GyroException.java
@@ -21,10 +21,16 @@ import gyro.lang.Locatable;
 public class GyroException extends RuntimeException {
 
     private final Locatable locatable;
+    private final Boolean showHelp;
 
-    public GyroException(Locatable locatable, String message, Throwable cause) {
+    public GyroException(Locatable locatable, String message, Throwable cause, Boolean showHelp) {
         super(message, cause);
         this.locatable = locatable;
+        this.showHelp = showHelp;
+    }
+
+    public GyroException(Locatable locatable, String message, Throwable cause) {
+        this(locatable, message, cause, false);
     }
 
     public GyroException(Locatable locatable, String message) {
@@ -39,8 +45,16 @@ public class GyroException extends RuntimeException {
         this(null, message, cause);
     }
 
+    public GyroException(String message, Throwable cause, Boolean showHelp) {
+        this(null, message, cause, showHelp);
+    }
+
     public GyroException(String message) {
         this(null, message, null);
+    }
+
+    public GyroException(String message, Boolean showHelp) {
+        this(null, message, null, showHelp);
     }
 
     public GyroException(Throwable cause) {
@@ -51,4 +65,7 @@ public class GyroException extends RuntimeException {
         return locatable;
     }
 
+    public Boolean showHelp() {
+        return showHelp;
+    }
 }


### PR DESCRIPTION
Fix: #356 