### PR TITLE
Enable verbose output by default

### DIFF
--- a/core/src/main/java/gyro/core/command/AbstractCommand.java
+++ b/core/src/main/java/gyro/core/command/AbstractCommand.java
@@ -44,7 +44,7 @@ public abstract class AbstractCommand implements GyroCommand, Callable<Integer> 
     public boolean debug;
 
     @Option(names = "--verbose", description = "Show values of attributes that changed.")
-    private boolean verbose;
+    private boolean verbose = true;
 
     private List<String> unparsedArguments;
 


### PR DESCRIPTION
Since the non-verbose view doesn't show the values of changed fields the default should be verbose mode.