### PR TITLE
Display elapsed time during execution

### DIFF
--- a/cli/src/main/java/gyro/cli/CliGyroUI.java
+++ b/cli/src/main/java/gyro/cli/CliGyroUI.java
@@ -50,6 +50,11 @@ public class CliGyroUI extends GyroAuditableUI {
         this.verbose = verbose;
     }
 
+    @Override
+    public boolean isIndented() {
+        return indentLevel != 0;
+    }
+
     public int getIndentSize() {
         return indentSize;
     }

--- a/core/src/main/java/gyro/core/GyroUI.java
+++ b/core/src/main/java/gyro/core/GyroUI.java
@@ -38,6 +38,8 @@ public interface GyroUI {
 
     void unindent();
 
+    boolean isIndented();
+
     void write(String message, Object... arguments);
 
     void replace(String message, Object... arguments);

--- a/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
+++ b/core/src/main/java/gyro/core/command/AbstractConfigCommand.java
@@ -216,7 +216,9 @@ public abstract class AbstractConfigCommand extends AbstractCommand {
                     processors.addAll(0, s.getSettings(ChangeSettings.class).getProcessors());
                 }
 
-                refreshes.add(new Refresh(resource, refreshService.submit(() -> {
+                refreshes.add(new Refresh(resource, ui, refreshService.submit(() -> {
+                    GyroCore.pushUi(ui);
+
                     started.incrementAndGet();
 
                     for (ChangeProcessor processor : processors) {
@@ -284,9 +286,11 @@ public abstract class AbstractConfigCommand extends AbstractCommand {
 
         public final Resource resource;
         public final Future<Boolean> future;
+        public final GyroUI ui;
 
-        public Refresh(Resource resource, Future<Boolean> future) {
+        public Refresh(Resource resource, GyroUI ui, Future<Boolean> future) {
             this.resource = resource;
+            this.ui = ui;
             this.future = future;
         }
 

--- a/core/src/main/java/gyro/core/diff/Change.java
+++ b/core/src/main/java/gyro/core/diff/Change.java
@@ -129,7 +129,7 @@ public abstract class Change {
         Diffable currentDiffable,
         Diffable pendingDiffable) {
 
-        ui.write("\n· %s: ", field.getName());
+        ui.write("\n  · %s: ", field.getName());
 
         Object currentValue = field.getValue(currentDiffable);
         Object pendingValue = field.getValue(pendingDiffable);

--- a/core/src/main/java/gyro/core/diff/Create.java
+++ b/core/src/main/java/gyro/core/diff/Create.java
@@ -45,7 +45,7 @@ public class Create extends Change {
 
         for (DiffableField field : DiffableType.getInstance(diffable.getClass()).getFields()) {
             if (!field.shouldBeDiffed() && configuredFields.contains(field.getName())) {
-                ui.write("\n· %s: %s", field.getName(), stringify(field.getValue(diffable)));
+                ui.write("\n  · %s: %s", field.getName(), stringify(field.getValue(diffable)));
             }
         }
     }

--- a/core/src/main/java/gyro/core/diff/Create.java
+++ b/core/src/main/java/gyro/core/diff/Create.java
@@ -62,10 +62,6 @@ public class Create extends Change {
     @Override
     public void writeExecution(GyroUI ui) {
         ui.write("@|magenta + Creating %s|@", getLabel(diffable, true));
-
-        if (ui.isVerbose()) {
-            writeFields(ui);
-        }
     }
 
     @Override

--- a/core/src/main/java/gyro/core/diff/Diff.java
+++ b/core/src/main/java/gyro/core/diff/Diff.java
@@ -390,15 +390,17 @@ public class Diff {
 
             if (!change.getDiffable().writePlan(ui, change)) {
                 change.writePlan(ui);
-            }
 
-            ui.write(ui.isVerbose() ? "\n\n" : "\n");
+                ui.write("\n");
+            }
 
             ui.indented(() -> {
                 for (Diff d : change.getDiffs()) {
                     d.write(ui);
                 }
             });
+
+            ui.write(!ui.isIndented() ? "\n" : "");
         }
 
         return written;

--- a/core/src/main/java/gyro/core/diff/ExecutionResult.java
+++ b/core/src/main/java/gyro/core/diff/ExecutionResult.java
@@ -22,13 +22,13 @@ public enum ExecutionResult {
 
     OK {
         public void write(GyroUI ui) {
-            ui.write(ui.isVerbose() ? "\n@|bold,green OK|@\n\n" : " @|bold,green OK|@\n");
+            ui.write(ui.isVerbose() ? "@|bold,green OK|@\n\n" : " @|bold,green OK|@\n");
         }
     },
 
     SKIPPED {
         public void write(GyroUI ui) {
-            ui.write(ui.isVerbose() ? "\n@|bold,yellow SKIPPED|@\n\n" : " @|bold,yellow SKIPPED|@\n");
+            ui.write(ui.isVerbose() ? "@|bold,yellow SKIPPED|@\n\n" : " @|bold,yellow SKIPPED|@\n");
         }
     };
 

--- a/core/src/main/java/gyro/core/diff/Update.java
+++ b/core/src/main/java/gyro/core/diff/Update.java
@@ -73,7 +73,6 @@ public class Update extends Change {
     @Override
     public void writeExecution(GyroUI ui) {
         ui.write("@|magenta ⟳ Updating %s|@", getLabel(currentDiffable, true));
-        writeFields(ui);
     }
 
     @Override

--- a/core/src/main/java/gyro/core/resource/ElapsedTimeChangeProcessor.java
+++ b/core/src/main/java/gyro/core/resource/ElapsedTimeChangeProcessor.java
@@ -1,0 +1,88 @@
+package gyro.core.resource;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import gyro.core.GyroUI;
+import gyro.core.diff.ChangeProcessor;
+import gyro.core.scope.State;
+import org.apache.commons.lang.time.StopWatch;
+
+public class ElapsedTimeChangeProcessor extends ChangeProcessor {
+
+    private Map<Resource, StopWatch> stopWatches = new HashMap<>();
+    private static final String ELAPSED_TIME_MESSAGE = " (elapsed time: @|green %s|@)";
+
+    private synchronized StopWatch start(Resource resource) {
+        StopWatch stopWatch = stopWatches.computeIfAbsent(resource, r -> new StopWatch());
+        stopWatch.reset();
+        stopWatch.start();
+
+        return stopWatch;
+    }
+
+    private synchronized String stop(GyroUI ui, Resource resource) {
+        StopWatch stopWatch = stopWatches.get(resource);
+        if (stopWatch == null) {
+            return "0ms";
+        }
+
+        stopWatch.stop();
+
+        Duration duration = Duration.ofMillis(stopWatch.getTime());
+
+        if (duration.getSeconds() <= 10) {
+            return String.format("%dms", duration.toMillis());
+        } else {
+            return String.format("%dm%ds", duration.toMinutes(), (duration.getSeconds() - (duration.toMinutes() * 60)));
+        }
+    }
+
+    @Override
+    public void beforeRefresh(GyroUI ui, Resource resource) throws Exception {
+        start(resource);
+    }
+
+    @Override
+    public void afterRefresh(GyroUI ui, Resource resource) throws Exception {
+        String elapsed = stop(ui, resource);
+        ui.write("Refreshing @|magenta,bold %s|@ took: @|green %s|@\n", resource.primaryKey(), elapsed);
+    }
+
+    @Override
+    public void beforeCreate(GyroUI ui, State state, Resource resource) throws Exception {
+        start(resource);
+    }
+
+    @Override
+    public void afterCreate(GyroUI ui, State state, Resource resource) throws Exception {
+        String elapsed = stop(ui, resource);
+        ui.write(ELAPSED_TIME_MESSAGE, elapsed);
+    }
+
+    @Override
+    public void beforeUpdate(
+        GyroUI ui, State state, Resource current, Resource pending, Set<DiffableField> changedFields) throws Exception {
+        start(pending);
+    }
+
+    @Override
+    public void afterUpdate(
+        GyroUI ui, State state, Resource current, Resource pending, Set<DiffableField> changedFields) throws Exception {
+        String elapsed = stop(ui, current);
+        ui.write(ELAPSED_TIME_MESSAGE, elapsed);
+    }
+
+    @Override
+    public void beforeDelete(GyroUI ui, State state, Resource resource) throws Exception {
+        start(resource);
+    }
+
+    @Override
+    public void afterDelete(GyroUI ui, State state, Resource resource) throws Exception {
+        String elapsed = stop(ui, resource);
+        ui.write(ELAPSED_TIME_MESSAGE, elapsed);
+    }
+}

--- a/core/src/main/java/gyro/core/resource/ElapsedTimeChangeProcessor.java
+++ b/core/src/main/java/gyro/core/resource/ElapsedTimeChangeProcessor.java
@@ -13,7 +13,7 @@ import org.apache.commons.lang.time.StopWatch;
 public class ElapsedTimeChangeProcessor extends ChangeProcessor {
 
     private Map<Resource, StopWatch> stopWatches = new HashMap<>();
-    private static final String ELAPSED_TIME_MESSAGE = " (elapsed time: @|green %s|@)";
+    private static final String ELAPSED_TIME_MESSAGE = " (elapsed time: @|green %s|@) ";
 
     private synchronized StopWatch start(Resource resource) {
         StopWatch stopWatch = stopWatches.computeIfAbsent(resource, r -> new StopWatch());

--- a/core/src/main/java/gyro/core/scope/RootScope.java
+++ b/core/src/main/java/gyro/core/scope/RootScope.java
@@ -79,6 +79,7 @@ import gyro.core.resource.Diffable;
 import gyro.core.resource.DiffableField;
 import gyro.core.resource.DiffableInternals;
 import gyro.core.resource.DiffableType;
+import gyro.core.resource.ElapsedTimeChangeProcessor;
 import gyro.core.resource.ExtendsDirectiveProcessor;
 import gyro.core.resource.ModificationChangeProcessor;
 import gyro.core.resource.ModificationPlugin;
@@ -178,7 +179,8 @@ public class RootScope extends FileScope {
 
         Stream.of(
             new ModificationChangeProcessor(),
-            new ConfiguredFieldsChangeProcessor())
+            new ConfiguredFieldsChangeProcessor(),
+            new ElapsedTimeChangeProcessor())
             .forEach(p -> getSettings(ChangeSettings.class).getProcessors().add(p));
 
         Stream.of(


### PR DESCRIPTION
This PR improves the output of Gyro by adding elapsed time to the execution output. Users will now see how long it took to create, update, delete, and refresh resources. The following will be appended to after each execution `(elapsed time: 0m32s)  OK`

```
$ gyro up accelerator.gyro 
Refreshing aws::route53-record-set::qa cloudfront-static-cache took: 1106ms
Refreshing aws::route53-record-set::qa cloudfront-content-cache took: 1107ms
<snip>
⟳ Refreshed resources: 61

Looking for changes...

- Delete aws::global-accelerator accelerator-qa (arn:aws:globalaccelerator::640415027344:accelerator/4d3d8089-fd95-4096-bb52-0ae44c2b89d5)
    - Delete attributes
    - Delete ip-sets 75.2.13.245, 99.83.162.33

- Delete aws::global-accelerator-listener accelerator-qa (arn:aws:globalaccelerator::640415027344:accelerator/4d3d8089-fd95-4096-bb52-0ae44c2b89d5/listener/667623d6)
    - Delete port-range 80:80
    - Delete port-range 443:443
    - Delete port-range 8443:8443

- Delete aws::global-accelerator-endpoint-group accelerator-qa (arn:aws:globalaccelerator::640415027344:accelerator/4d3d8089-fd95-4096-bb52-0ae44c2b89d5/listener/667623d6/endpoint-group/f1563b651002)
    - Delete endpoint-configuration arn:aws:elasticloadbalancing:us-east-1:640415027344:loadbalancer/app/brightspot-cloud-k12-qa/c8580f9d493ea86f


Are you sure you want to change resources? (y/N) y

- Deleting aws::global-accelerator-endpoint-group accelerator-qa (arn:aws:globalaccelerator::640415027344:accelerator/4d3d8089-fd95-4096-bb52-0ae44c2b89d5/listener/667623d6/endpoint-group/f1563b651002) (elapsed time: 810ms)  OK
- Deleting aws::global-accelerator-listener accelerator-qa (arn:aws:globalaccelerator::640415027344:accelerator/4d3d8089-fd95-4096-bb52-0ae44c2b89d5/listener/667623d6) (elapsed time: 149ms)  OK
- Deleting aws::global-accelerator accelerator-qa (arn:aws:globalaccelerator::640415027344:accelerator/4d3d8089-fd95-4096-bb52-0ae44c2b89d5) (elapsed time: 0m32s)  OK

```