### PR TITLE
Catch class cast exception during parsing

### DIFF
--- a/core/src/main/java/gyro/core/scope/NodeEvaluator.java
+++ b/core/src/main/java/gyro/core/scope/NodeEvaluator.java
@@ -712,7 +712,15 @@ public class NodeEvaluator implements NodeVisitor<Scope, Object, RuntimeExceptio
                     }
 
                     // Remove duplicate arguments
-                    Set<String> argumentSet = arguments.stream().map(o -> (String) o).collect(Collectors.toSet());
+                    Set<String> argumentSet;
+                    try {
+                        argumentSet = arguments.stream().map(o -> (String) o).collect(Collectors.toSet());
+                    } catch (java.lang.ClassCastException cce) {
+                        throw new GyroException(
+                            node,
+                            String.format("Can't resolve @|bold %s|@ reference!", referenceName),
+                            cce);
+                    }
 
                     for (Object argument : argumentSet) {
                         Object resourceValue = resourceResolver((String) argument, referenceName, node, root);


### PR DESCRIPTION
One place this can happen is when a reference resolver that expects a map is used but the plugin that defines the resolver isn't loaded.

Example:

```
@print: $(custom::resolver "abc" {
    "a": "b"
})
```

This will result in:

```
Caused by: Unexpected error: java.lang.ClassCastException: class java.util.LinkedHashMap cannot be cast to class java.lang.String (java.util.LinkedHashMap and java.lang.String are in module java.base of loader 'bootstrap')
	at gyro.core.scope.NodeEvaluator.lambda$visitReference$41(NodeEvaluator.java:717)
```

With this code change it'll result in:

```
Error: Can't process the @print directive!

In test.gyro from line 2 at column 1 to line 4 at column 2:
2: @print: $(custom::resolver "abc" { 
3:     "a": "b"
4: })

Caused by: Error: Can't resolve custom::resolver reference!

In test.gyro from line 2 at column 9 to line 4 at column 2:
2: @print: $(custom::resolver "abc" { 
3:     "a": "b"
4: })

Caused by: Unexpected error: java.lang.ClassCastException: class java.util.LinkedHashMap cannot be cast to class java.lang.String (java.util.LinkedHashMap and java.lang.String are in module java.base of loader 'bootstrap')

```