### PR TITLE
Allow parent to be set using DiffableInternals

### DIFF
--- a/core/src/main/java/gyro/core/resource/DiffableInternals.java
+++ b/core/src/main/java/gyro/core/resource/DiffableInternals.java
@@ -83,6 +83,10 @@ public final class DiffableInternals {
         diffable.change = change;
     }
 
+    public static void setParent(Diffable diffable, Diffable parent) {
+        diffable.parent = parent;
+    }
+
     public static void reevaluate(Diffable diffable) {
         DiffableScope oldScope = diffable.scope;
 


### PR DESCRIPTION
This allows Gyro subresources to be created outside of the parent resource and then attached. This is useful for generating Gyro resources programmatically from a non-Gyro data source.