### PR TITLE
Handle NPE on options validator

### DIFF
--- a/core/src/main/java/gyro/core/OptionArgumentProcessor.java
+++ b/core/src/main/java/gyro/core/OptionArgumentProcessor.java
@@ -79,7 +79,7 @@ public class OptionArgumentProcessor {
             }
 
             throw new GyroException(
-                hasMaximum ? arguments.get(maximum) : locatable,
+                locatable,
                 String.format(
                     "%s requires %s arguments!",
                     errorName,


### PR DESCRIPTION
This occurs when the the number of arguments passed is less than the minimum of a resolver that also has a maximum set.

example:

`$(kubernetes::string-replace "something")`

where the string replace resolver has max and min set to 3.

This results in :

```
Error: Can't process the @print directive!

In test.gyro on line 1 from column 1 to 49:
1: @print: $(kubernetes::string-replace "something")

Caused by: Error: Can't resolve kubernetes::string-replace reference!

In test.gyro on line 1 from column 9 to 49:
1: @print: $(kubernetes::string-replace "something")

Caused by: Unexpected error: java.lang.IndexOutOfBoundsException: Index 3 out of bounds for length 1
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248)
	at java.base/java.util.Objects.checkIndex(Objects.java:372)
	at java.base/java.util.ArrayList.get(ArrayList.java:458)
	at gyro.core.OptionArgumentProcessor.validate(OptionArgumentProcessor.java:82)
	at gyro.core.OptionArgumentProcessor.validateArguments(OptionArgumentProcessor.java:122)
	at gyro.plugin.kubernetes.StringReplaceResolver.resolve(StringReplaceResolver.java:15)
	at gyro.core.scope.NodeEvaluator.visitReference(NodeEvaluator.java:695)
	at gyro.core.scope.NodeEvaluator.visitReference(NodeEvaluator.java:81)
	at gyro.lang.ast.value.ReferenceNode.accept(ReferenceNode.java:56)
	at gyro.lang.ast.NodeVisitor.visit(NodeVisitor.java:37)
	at gyro.core.OptionArgumentProcessor.convert(OptionArgumentProcessor.java:106)
	at gyro.core.OptionArgumentProcessor.getArgument(OptionArgumentProcessor.java:131)
	at gyro.core.PrintDirectiveProcessor.process(PrintDirectiveProcessor.java:32)
	at gyro.core.scope.NodeEvaluator.visitDirective(NodeEvaluator.java:387)
	at gyro.core.scope.NodeEvaluator.visitDirective(NodeEvaluator.java:81)
	at gyro.lang.ast.block.DirectiveNode.accept(DirectiveNode.java:77)
	at gyro.lang.ast.NodeVisitor.visit(NodeVisitor.java:37)
	at gyro.core.scope.NodeEvaluator.lambda$evaluateBody$31(NodeEvaluator.java:345)
	at gyro.core.scope.Defer.execute(Defer.java:50)
	at gyro.core.scope.NodeEvaluator.evaluateBody(NodeEvaluator.java:345)
	at gyro.core.scope.NodeEvaluator.visitFile(NodeEvaluator.java:428)
	at gyro.core.scope.NodeEvaluator.visitFile(NodeEvaluator.java:81)
	at gyro.lang.ast.block.FileNode.accept(FileNode.java:32)
	at gyro.lang.ast.NodeVisitor.visit(NodeVisitor.java:37)
	at gyro.core.scope.NodeEvaluator.lambda$evaluateBody$31(NodeEvaluator.java:345)
	at gyro.core.scope.Defer.execute(Defer.java:50)
	at gyro.core.scope.NodeEvaluator.evaluateBody(NodeEvaluator.java:345)
	at gyro.core.scope.NodeEvaluator.evaluate(NodeEvaluator.java:329)
	at gyro.core.scope.RootScope.evaluate(RootScope.java:433)
	at gyro.core.command.AbstractConfigCommand.doExecute(AbstractConfigCommand.java:179)
	at gyro.core.command.AbstractCommand.execute(AbstractCommand.java:75)
	at gyro.core.command.AbstractCommand.call(AbstractCommand.java:80)
	at gyro.core.command.AbstractCommand.call(AbstractCommand.java:41)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1933)
	at picocli.CommandLine.access$1100(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2332)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2326)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2291)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2159)
	at picocli.CommandLine.execute(CommandLine.java:2058)
	at gyro.cli.Gyro.run(Gyro.java:267)
	at gyro.cli.Gyro.main(Gyro.java:89)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:48)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:87)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:50)
	at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:51)


```