### PR TITLE
Fix stub error handling when java not installed

### DIFF
--- a/cli/scripts/stub.sh
+++ b/cli/scripts/stub.sh
@@ -15,18 +15,17 @@ java=$EXECUTION_DIRECTORY/gyro-rt/bin/java
 if [ ! -x $java ];
 then
     java=`which java 2>/dev/null` || java=$JAVA_HOME/bin/java
+    if [ ! -x $java ];
+    then
+        echo "ERROR: Unable to locate a Java 11 runtime."
+        exit 1;
+    fi
 fi
 
 # Suppress JDK9+ reflection warnings.
 if [ `$java -version 2>&1 | grep -c 1\.8\.0` -eq "0" ];
 then
     export JAVA_OPTS="$JAVA_OPTS --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.annotation=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.module=ALL-UNNAMED --add-opens=java.base/java.lang.ref=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.math=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.net.spi=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.nio.channels=ALL-UNNAMED --add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED --add-opens=java.base/java.nio.charset=ALL-UNNAMED --add-opens=java.base/java.nio.charset.spi=ALL-UNNAMED --add-opens=java.base/java.nio.file=ALL-UNNAMED --add-opens=java.base/java.nio.file.attribute=ALL-UNNAMED --add-opens=java.base/java.nio.file.spi=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.security.acl=ALL-UNNAMED --add-opens=java.base/java.security.cert=ALL-UNNAMED --add-opens=java.base/java.security.interfaces=ALL-UNNAMED --add-opens=java.base/java.security.spec=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.base/java.text.spi=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-opens=java.base/java.time.chrono=ALL-UNNAMED --add-opens=java.base/java.time.format=ALL-UNNAMED --add-opens=java.base/java.time.temporal=ALL-UNNAMED --add-opens=java.base/java.time.zone=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED --add-opens=java.base/java.util.function=ALL-UNNAMED --add-opens=java.base/java.util.jar=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED --add-opens=java.base/java.util.spi=ALL-UNNAMED --add-opens=java.base/java.util.stream=ALL-UNNAMED --add-opens=java.base/java.util.zip=ALL-UNNAMED --add-opens=java.datatransfer/java.awt.datatransfer=ALL-UNNAMED --add-opens=java.instrument/java.lang.instrument=ALL-UNNAMED --add-opens=java.logging/java.util.logging=ALL-UNNAMED --add-opens=java.management/java.lang.management=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xpath.internal=ALL-UNNAMED"
-fi
-
-if [ ! -x $java ];
-then
-    echo "ERROR: Unable to locate a Java 11 runtime."
-    exit 1;
 fi
 
 exec "$java" $JAVA_OPTS $java_args -Dgyro.app=$0 -jar $MYSELF "$@"

--- a/cli/scripts/stub.sh
+++ b/cli/scripts/stub.sh
@@ -14,11 +14,7 @@ fi
 java=$EXECUTION_DIRECTORY/gyro-rt/bin/java
 if [ ! -x $java ];
 then
-    java=`which java`
-    if [ ! -x $java ];
-    then
-        java=$JAVA_HOME/bin/java
-    fi
+    java=`which java 2>/dev/null` || java=$JAVA_HOME/bin/java
 fi
 
 # Suppress JDK9+ reflection warnings.


### PR DESCRIPTION
On a clean ubuntu box without `java` installed:
```
root@3f0b37f10052:~# curl -sL -o /usr/local/bin/gyro https://artifactory.psdops.com/gyro-releases/gyro/gyro-cli-linux/1.1.3rc2/gyro-cli-linux-1.1.3rc2
root@3f0b37f10052:~# chmod a+x /usr/local/bin/gyro
root@3f0b37f10052:~# gyro
/usr/local/bin/gyro: 36: exec: : Permission denied
```

after proposed changes:
```
root@3f0b37f10052:~# gyro
ERROR: Unable to locate a Java 11 runtime.
```