### PR TITLE
Added flag to the gyro diff to provide exit code

### DIFF
--- a/core/src/main/java/gyro/core/command/DiffCommand.java
+++ b/core/src/main/java/gyro/core/command/DiffCommand.java
@@ -22,6 +22,7 @@ import gyro.core.diff.Diff;
 import gyro.core.scope.RootScope;
 import gyro.core.scope.State;
 import picocli.CommandLine.Command;
+
 import static picocli.CommandLine.Option;
 
 @Command(name = "diff",

--- a/core/src/main/java/gyro/core/command/DiffCommand.java
+++ b/core/src/main/java/gyro/core/command/DiffCommand.java
@@ -22,6 +22,7 @@ import gyro.core.diff.Diff;
 import gyro.core.scope.RootScope;
 import gyro.core.scope.State;
 import picocli.CommandLine.Command;
+import static picocli.CommandLine.Option;
 
 @Command(name = "diff",
     header = "Shows differences between the configuration and the cloud.",
@@ -35,6 +36,11 @@ import picocli.CommandLine.Command;
     versionProvider = VersionCommand.class
 )
 public class DiffCommand extends AbstractConfigCommand {
+
+    @Option(names = { "--exitcode" }, description = "Exit with exit code")
+    public boolean exitWithCode;
+
+    private int exitCode = 0;
 
     @Override
     public void doExecute(RootScope current, RootScope pending, State state) throws Exception {
@@ -50,6 +56,14 @@ public class DiffCommand extends AbstractConfigCommand {
 
         if (!diff.write(ui)) {
             ui.write("\n@|bold,green No changes.|@\n\n");
+        } else if (exitWithCode) { // pending changes && exit with exit code
+            exitCode = 16;
         }
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        execute();
+        return exitCode;
     }
 }

--- a/core/src/main/java/gyro/core/command/DiffCommand.java
+++ b/core/src/main/java/gyro/core/command/DiffCommand.java
@@ -38,7 +38,7 @@ import static picocli.CommandLine.Option;
 )
 public class DiffCommand extends AbstractConfigCommand {
 
-    @Option(names = "--exitcode", description = "Exit with exit code")
+    @Option(names = "--exitcode", description = "Exit with exit code 3 when a diff is detected")
     public boolean exitWithCode;
 
     private int exitCode = 0;
@@ -58,7 +58,7 @@ public class DiffCommand extends AbstractConfigCommand {
         if (!diff.write(ui)) {
             ui.write("\n@|bold,green No changes.|@\n\n");
         } else if (exitWithCode) { // pending changes && exit with exit code
-            exitCode = 1;
+            exitCode = 3;
         }
     }
 

--- a/core/src/main/java/gyro/core/command/DiffCommand.java
+++ b/core/src/main/java/gyro/core/command/DiffCommand.java
@@ -38,7 +38,7 @@ import static picocli.CommandLine.Option;
 )
 public class DiffCommand extends AbstractConfigCommand {
 
-    @Option(names = { "--exitcode" }, description = "Exit with exit code")
+    @Option(names = "--exitcode", description = "Exit with exit code")
     public boolean exitWithCode;
 
     private int exitCode = 0;

--- a/core/src/main/java/gyro/core/command/DiffCommand.java
+++ b/core/src/main/java/gyro/core/command/DiffCommand.java
@@ -57,7 +57,7 @@ public class DiffCommand extends AbstractConfigCommand {
         if (!diff.write(ui)) {
             ui.write("\n@|bold,green No changes.|@\n\n");
         } else if (exitWithCode) { // pending changes && exit with exit code
-            exitCode = 16;
+            exitCode = 1;
         }
     }
 


### PR DESCRIPTION
Added `--exitcode` flag to the `gyro diff` command to provide a non-zero exit code when a diff is detected.